### PR TITLE
Multiple versions of albacore gem were causing rake to fail. 

### DIFF
--- a/RakeFile
+++ b/RakeFile
@@ -1,4 +1,5 @@
 require 'fileutils'
+gem 'albacore', '=0.1.5'
 require 'albacore'
 require 'tools/albacore/zipdirectory_patch.rb'
 


### PR DESCRIPTION
Patched the rakefile with a gem statement requiring the correct (elder) albacore.

I ran into this because we have a project on the current version of albacore.

Learned how to do it on SO: http://stackoverflow.com/questions/2693862/how-do-i-require-a-specific-version-of-a-ruby-gem
