### PR TITLE
ExpressionToSql support for Booleans

### DIFF
--- a/src/FluentNHibernate.Testing/DomainModel/Mapping/ClassMapXmlCreationTester.cs
+++ b/src/FluentNHibernate.Testing/DomainModel/Mapping/ClassMapXmlCreationTester.cs
@@ -582,6 +582,7 @@ namespace FluentNHibernate.Testing.DomainModel.Mapping
         public virtual int Id { get; set; }
         public virtual string Name { get; set; }
         public virtual int Position { get; set; }
+        public virtual bool Active { get; set; }
     }
 
     public class MappedGenericObject<T>

--- a/src/FluentNHibernate.Testing/ExpressionToSqlTests.cs
+++ b/src/FluentNHibernate.Testing/ExpressionToSqlTests.cs
@@ -56,6 +56,38 @@ namespace FluentNHibernate.Testing
         }
 
         [Test]
+        public void ConvertEqualsPropertyAndTrue()
+        {
+            var sql = ExpressionToSql.Convert<ChildObject>(x => x.Active == true);
+
+            sql.ShouldEqual("Active = 1");
+        }
+
+        [Test]
+        public void ConvertEqualsPropertyAndFalse()
+        {
+            var sql = ExpressionToSql.Convert<ChildObject>(x => x.Active == false);
+
+            sql.ShouldEqual("Active = 0");
+        }
+
+        [Test]
+        public void ConvertBooleanPropertyImplicitTrue()
+        {
+            var sql = ExpressionToSql.Convert<ChildObject>(x => x.Active);
+
+            sql.ShouldEqual("Active = 1");
+        }
+
+        [Test]
+        public void ConvertBooleanPropertyImplicitFalse()
+        {
+            var sql = ExpressionToSql.Convert<ChildObject>(x => !x.Active);
+
+            sql.ShouldEqual("Active = 0");
+        }
+
+        [Test]
         public void ConvertGreater()
         {
             var sql = ExpressionToSql.Convert<ChildObject>(x => x.Position > 1);

--- a/src/FluentNHibernate/Utils/ExpressionToSql.cs
+++ b/src/FluentNHibernate/Utils/ExpressionToSql.cs
@@ -32,6 +32,14 @@ namespace FluentNHibernate.Utils
         {
             if (expression.Body is BinaryExpression)
                 return Convert<T>((BinaryExpression)expression.Body);
+            var memberExpression = expression.Body as MemberExpression;
+            if (memberExpression != null && memberExpression.Type == typeof(bool))
+                    return Convert(CreateExpression<T>(memberExpression)) + " = " + Convert(true);
+            var unaryExpression = expression.Body as UnaryExpression;
+            if (unaryExpression != null && unaryExpression.Type == typeof(bool) && unaryExpression.NodeType == ExpressionType.Not)
+                    return Convert(CreateExpression<T>(unaryExpression.Operand)) + " = " + Convert(false);
+                
+
 
             throw new NotImplementedException();
         }
@@ -135,6 +143,10 @@ namespace FluentNHibernate.Utils
         {
             if (value is string)
                 return "'" + value + "'";
+            if (value is bool)
+            {
+                return (bool)value ? "1" : "0";
+            }
             
             return value.ToString();
         }


### PR DESCRIPTION
As I said in my commit message - my Expression experience/knowledge is limited, but I attempted to add support for booleans.  My specific use case was on a HasMany mapping with a .Where() expression.  I wanted to enable the following:
.Where(x => x.Active == true)
.Where(x => x.Active == false)
.Where(x => x.Active)
.Where(x => !x.Active)

Tests all pass, but let me know if there are any flaws in my implementation!
