### PR TITLE
Mapping an interface to a column

### DIFF
--- a/src/FluentNHibernate/Mapping/Member.cs
+++ b/src/FluentNHibernate/Mapping/Member.cs
@@ -432,7 +432,7 @@ namespace FluentNHibernate
             type.GetInstanceFields().Each(x => members.Add(x));
             type.GetInstanceMethods().Each(x => members.Add(x));
 
-            if (type.BaseType != typeof(object))
+            if (type.BaseType != null && type.BaseType != typeof(object))
                 type.BaseType.GetInstanceMembers().Each(x => members.Add(x));
 
             return members;


### PR DESCRIPTION
When mapping an interface to a colum using UserType the class Member throws an exception because typeof(interface).BaseType is null. I just added a simple condition to the if clause.
