### PR TITLE
Overriding SubClass discriminator for automapping

### DIFF
--- a/src/FluentNHibernate.Testing/AutoMapping/Apm/AutoPersistenceModelTests.Inheritance.cs
+++ b/src/FluentNHibernate.Testing/AutoMapping/Apm/AutoPersistenceModelTests.Inheritance.cs
@@ -189,6 +189,18 @@ namespace FluentNHibernate.Testing.AutoMapping.Apm
         }
 
         [Test]
+        public void TestInheritanceSubclassSpecifyingDiscriminatorValue()
+        {
+            var autoMapper = AutoMap.AssemblyOf<ExampleClass>()
+                .Setup(x => x.IsDiscriminated = type => true)
+                .Override<ExampleClass>(t => t.SubClass<ExampleInheritedClass>("example"))
+                .Where(t => t.Namespace == "FluentNHibernate.Automapping.TestFixtures");
+
+            new AutoMappingTester<ExampleClass>(autoMapper)
+                .Element("class/subclass").HasAttribute("discriminator-value", "example");
+        }
+
+        [Test]
         public void TestInheritanceSubclassOverridingMappingProperties()
         {
             var autoMapper = AutoMap.AssemblyOf<ExampleClass>()
@@ -197,8 +209,9 @@ namespace FluentNHibernate.Testing.AutoMapping.Apm
                 .Where(t => t.Namespace == "FluentNHibernate.Automapping.TestFixtures");
 
             new AutoMappingTester<ExampleClass>(autoMapper)
-                .Element("class/subclass")
-                .ChildrenDontContainAttribute("name", "LineOne");
+                .Element("class/subclass/property[@name='ExampleProperty']/column")
+                .Exists()
+                .HasAttribute("name", "columnName");
         }
 
         [Test]

--- a/src/FluentNHibernate/Automapping/AutoMapping.cs
+++ b/src/FluentNHibernate/Automapping/AutoMapping.cs
@@ -67,6 +67,9 @@ namespace FluentNHibernate.Automapping
                 classMapping.Tuplizer = providers.TuplizerMapping;
             }
 
+            foreach (var subclassEntry in providers.Subclasses)
+                MergeSubclass(mapping, subclassEntry.Key, subclassEntry.Value);
+
             foreach (var property in providers.Properties)
                 mapping.AddOrReplaceProperty(property.GetPropertyMapping());
 
@@ -90,6 +93,19 @@ namespace FluentNHibernate.Automapping
 
             foreach (var filter in providers.Filters)
                 mapping.AddOrReplaceFilter(filter.GetFilterMapping());
+        }
+
+        private void MergeSubclass(ClassMappingBase mapping, Type subclassType, ISubclassMappingProvider subclass)
+        {
+            var subclassMapping = mapping.Subclasses.SingleOrDefault(s => s.Type == subclassType);
+            if (subclassMapping != null)
+            {
+                ((IAutoClasslike)subclass).AlterModel(subclassMapping);
+            }
+            else
+            {
+                mapping.AddSubclass(subclass.GetSubclassMapping());
+            }
         }
 
         [Obsolete("Do not call this method. Implementation detail mistakenly made public. Will be made private in next version.")]


### PR DESCRIPTION
I have added calls AutoSubClassPart.AlterModel into AutoMapping.AlterModel.
My main scenario was to get the discriminator value override working, so I added a test for discriminator value and modified the property test that didn't seem to to check anything.

In general, it would be much nicer if I could specify the discriminator in IAutoMappingOverride<ChildClass>, but for now I decided not to touch the API and only fix the thing that looked like it should have been working.
