### PR TITLE
Bug: Explicit MetaType clears out MetaValues

### DIFF
--- a/src/FluentNHibernate.Testing/DomainModel/Mapping/AnyPartTester.cs
+++ b/src/FluentNHibernate.Testing/DomainModel/Mapping/AnyPartTester.cs
@@ -173,5 +173,27 @@ namespace FluentNHibernate.Testing.DomainModel.Mapping
 
             mapTest.Element("class/id").ShouldBeInParentAtPosition(0);
         }
+
+
+        [Test]
+        public void SpecificMetaTypeShouldNotClearMetaValues()
+        {
+            var mapTest = new MappingTester<MappedObject>()
+                .ForMapping(map =>
+                {
+                    map.Id(x => x.Id);
+                    map.ReferencesAny(x => x.Parent)
+                        .EntityIdentifierColumn("AnyId")
+                        .EntityTypeColumn("AnyType")
+                        .IdentityType(x => x.Id)
+                        .MetaType<int>()
+                        .AddMetaValue<SecondMappedObject>("1");
+                });
+
+            mapTest
+                .Element("class/any/meta-value")
+                .HasAttribute("value", "1")
+                .HasAttribute("class", typeof(SecondMappedObject).AssemblyQualifiedName);
+        }
     }
 }

--- a/src/FluentNHibernate/Mapping/AnyPart.cs
+++ b/src/FluentNHibernate/Mapping/AnyPart.cs
@@ -156,15 +156,10 @@ namespace FluentNHibernate.Mapping
             if (!mapping.IsSpecified("Name"))
                 mapping.Name = property.Name;
 
+            metaValues.Each(mapping.AddMetaValue);
             if (!mapping.IsSpecified("MetaType"))
             {
-                if (metaValues.Count() > 0)
-                {
-                    metaValues.Each(mapping.AddMetaValue);
-                    mapping.MetaType = new TypeReference(typeof(string));
-                }
-                else
-                    mapping.MetaType = new TypeReference(property.PropertyType);
+                mapping.MetaType = metaValues.Count() > 0 ? new TypeReference(typeof(string)) : new TypeReference(property.PropertyType);
             }
 
             foreach (var column in typeColumns)


### PR DESCRIPTION
Fixed bug with explicit MetaType on ReferencesAny mapping clearing out meta values.

Also included an unit test.
