### PR TITLE
PersistenceSpecification in a TransactionScope

### DIFF
--- a/src/FluentNHibernate/Testing/PersistenceSpecification.cs
+++ b/src/FluentNHibernate/Testing/PersistenceSpecification.cs
@@ -11,7 +11,7 @@ namespace FluentNHibernate.Testing
         protected readonly List<Property<T>> allProperties = new List<Property<T>>();
         private readonly ISession currentSession;
         private readonly IEqualityComparer entityEqualityComparer;
-        private readonly bool hasExistingSession;
+        private readonly bool hasExistingTransaction;
 
         public PersistenceSpecification(ISessionSource source)
             : this(source.CreateSession())
@@ -31,7 +31,7 @@ namespace FluentNHibernate.Testing
         public PersistenceSpecification(ISession session, IEqualityComparer entityEqualityComparer)
         {
             currentSession = session;
-            hasExistingSession = currentSession.Transaction != null && currentSession.Transaction.IsActive;
+            hasExistingTransaction = currentSession.Transaction != null && currentSession.Transaction.IsActive || System.Transactions.Transaction.Current != null;
             this.entityEqualityComparer = entityEqualityComparer;
         }
 
@@ -68,7 +68,7 @@ namespace FluentNHibernate.Testing
 
         public void TransactionalSave(object propertyValue)
         {
-            if (hasExistingSession)
+            if (hasExistingTransaction)
             {
                 currentSession.Save(propertyValue);
             }


### PR DESCRIPTION
Checking for an existing transaction now also checks for a System.Transactions.Transaction (comes in handy when doing test on Oracle and you don't want MSDTC to kick in because of nested transactions)
