### PR TITLE
Extension method overloads for PersistenceSpecification

### DIFF
--- a/src/FluentNHibernate.Testing/Testing/PersistenceSpecificationTester.cs
+++ b/src/FluentNHibernate.Testing/Testing/PersistenceSpecificationTester.cs
@@ -146,6 +146,16 @@ namespace FluentNHibernate.Testing.Testing
         }
 
         [Test]
+        public void Comparing_objects_in_two_lists_should_use_the_specified_comparisons()
+        {
+            _spec.CheckList(x => x.AllKittens, _cat.AllKittens, kitten => kitten.Id).VerifyTheMappings();
+
+            // Should fail because the names don't match.
+            Assert.Throws<ApplicationException>(() => _spec.CheckList(x => x.AllKittens, _cat.AllKittens, kitten => kitten.Id, kitten => kitten.Name)
+                .VerifyTheMappings());
+        }
+
+        [Test]
         public void Can_test_enumerable()
         {
             var kittens = new[] {new Kitten {Id = 3, Name = "kitten3"}, new Kitten {Id = 4, Name = "kitten4"}};
@@ -174,6 +184,7 @@ namespace FluentNHibernate.Testing.Testing
         {
             _spec.CheckReference(cat => cat.FirstKitten, _cat.FirstKitten, x => x.Id).VerifyTheMappings();
 
+            // Should fail because the names don't match.
             Assert.Throws<ApplicationException>(() => _spec.CheckReference(cat => cat.FirstKitten, _cat.FirstKitten, x => x.Id, x => x.Name)
                 .VerifyTheMappings());
         }

--- a/src/FluentNHibernate/Testing/PersistenceSpecificationExtensions.cs
+++ b/src/FluentNHibernate/Testing/PersistenceSpecificationExtensions.cs
@@ -136,6 +136,19 @@ namespace FluentNHibernate.Testing
         }
 
         public static PersistenceSpecification<T> CheckList<T, TListElement>(this PersistenceSpecification<T> spec,
+                                                                            Expression<Func<T, IEnumerable<TListElement>>> expression,
+                                                                            IEnumerable<TListElement> propertyValue,
+                                                                            params Func<TListElement, object>[] propertiesToCompare)
+        {
+            // Because of the params keyword, the compiler can select this overload
+            // instead of the one above, even when no funcs are supplied in the method call.
+            if (propertiesToCompare == null || propertiesToCompare.Length == 0)
+                return spec.CheckList(expression, propertyValue, (IEqualityComparer)null);
+
+            return spec.CheckList(expression, propertyValue, new FuncEqualityComparer<TListElement>(propertiesToCompare));
+        }
+
+        public static PersistenceSpecification<T> CheckList<T, TListElement>(this PersistenceSpecification<T> spec,
                                                                               Expression<Func<T, IEnumerable<TListElement>>> expression,
                                                                               IEnumerable<TListElement> propertyValue,
                                                                               Action<T, TListElement> listItemSetter)


### PR DESCRIPTION
Added overloads in PersistenceSpecificationExtensions so you can specify the properties of the reference to compare without creating a custom IEqualityComparer.  This uses the comparison pattern described here: http://paceyourself.net/2010/09/20/refactoring-object-comparison-code-in-c/

This allows you to create a PersistenceSpecification like the following if you just want to compare IDs:

<pre>
    new PersistenceSpecification&lt;Blog&gt;(session)
        .CheckReference(blog => blog.Author, someAuthor, author => author.Id)
        .VerifyTheMappings();
</pre>

or you can compare multiple properties:

<pre>
    new PersistenceSpecification&lt;Blog&gt;(session)
        .CheckReference(blog => blog.Author, someAuthor, author => author.Name, author => author.Email)
        .VerifyTheMappings();
</pre>

and you don't need to create an IEqualityComparer for every type of reference you test.
