### PR TITLE
Fix for UseUnionSubclassForInheritanceMapping not working with AutoMapping

### DIFF
--- a/src/FluentNHibernate.Testing/AutoMapping/UnionSubclassConventionTests.cs
+++ b/src/FluentNHibernate.Testing/AutoMapping/UnionSubclassConventionTests.cs
@@ -1,0 +1,22 @@
+using FluentNHibernate.Automapping;
+using FluentNHibernate.Automapping.TestFixtures.SuperTypes;
+using NUnit.Framework;
+
+namespace FluentNHibernate.Testing.Automapping
+{
+    [TestFixture]
+    public class UnionSubclassConventionTests
+    {
+        [Test]
+        public void DefaultConventionsAreAppliedToUnionSubClasses()
+        {
+            new AutoMappingTester<SuperType>(
+                AutoMap.AssemblyOf<SuperType>()
+                    .Where(x => x.Namespace == typeof(SuperType).Namespace)
+                    .Override<SuperType>(m => m.UseUnionSubclassForInheritanceMapping()))
+                .Element("class/union-subclass[@name='" + typeof(ExampleClass).AssemblyQualifiedName + "']/many-to-one/column")
+                .HasAttribute("name", "Parent_id");
+            //.Element("class/union-subclass").Exists();
+        }
+    }
+}

--- a/src/FluentNHibernate.Testing/AutoMapping/UnionSubclassTests.cs
+++ b/src/FluentNHibernate.Testing/AutoMapping/UnionSubclassTests.cs
@@ -1,0 +1,20 @@
+using FluentNHibernate.Automapping;
+using FluentNHibernate.Automapping.TestFixtures.SuperTypes;
+using NUnit.Framework;
+
+namespace FluentNHibernate.Testing.Automapping
+{
+    [TestFixture]
+    public class UnionSubclassTests
+    {
+        [Test]
+        public void WhenOverloadedWithUseUnionSubclassForInheritanceMappingUnionSubclassElementShouldExists()
+        {
+            new AutoMappingTester<SuperType>(
+                AutoMap.AssemblyOf<SuperType>()
+                    .Where(x => x.Namespace == typeof(SuperType).Namespace)
+                    .Override<SuperType>(m => m.UseUnionSubclassForInheritanceMapping()))
+                .Element("class/union-subclass").Exists();
+        }
+    }
+}

--- a/src/FluentNHibernate.Testing/FluentNHibernate.Testing.csproj
+++ b/src/FluentNHibernate.Testing/FluentNHibernate.Testing.csproj
@@ -121,6 +121,8 @@
     <Compile Include="AutoMapping\Overrides\CompositeIdOverrides.cs" />
     <Compile Include="AutoMapping\Overrides\HibernateMappingOverrides.cs" />
     <Compile Include="AutoMapping\Overrides\ParentOverridesWithSubclasses.cs" />
+    <Compile Include="AutoMapping\UnionSubclassConventionTests.cs" />
+    <Compile Include="AutoMapping\UnionSubclassTests.cs" />
     <Compile Include="StubTypeSource.cs" />
     <Compile Include="AutoMapping\TestFixtures.cs" />
     <Compile Include="Cfg\Db\DB2ConfigurationTester.cs" />

--- a/src/FluentNHibernate/Automapping/AutoMapper.cs
+++ b/src/FluentNHibernate/Automapping/AutoMapper.cs
@@ -58,7 +58,9 @@ namespace FluentNHibernate.Automapping
                 .Where(x => x.Value != null && x.Value.Type == classType)
                 .Select(x => x.Key))
             {
-                if (isDiscriminated && !discriminatorSet && mapping is ClassMapping)
+                var tempMapping = mapping as ClassMapping;
+                var tempIsNull = tempMapping == null;
+                if (isDiscriminated && !discriminatorSet && !tempIsNull)
                 {
                     var discriminatorColumn = cfg.GetDiscriminatorColumn(classType);
                     var discriminator = new DiscriminatorMapping
@@ -68,13 +70,20 @@ namespace FluentNHibernate.Automapping
                     };
                     discriminator.AddDefaultColumn(new ColumnMapping { Name = discriminatorColumn });
 
-                    ((ClassMapping)mapping).Discriminator = discriminator;
+                    tempMapping.Discriminator = discriminator;
                     discriminatorSet = true;
                 }
 
                 SubclassMapping subclassMapping;
 
-                if (!isDiscriminated)
+                if(!tempIsNull && tempMapping.IsUnionSubclass)
+                {
+                    subclassMapping = new SubclassMapping(SubclassType.UnionSubclass)
+                    {
+                        Type = inheritedClass.Type
+                    };
+                }
+                else if(!isDiscriminated)
                 {
                     subclassMapping = new SubclassMapping(SubclassType.JoinedSubclass)
                     {


### PR DESCRIPTION
Fix for AutoMapping issue when UseUnionSubclassForInheritanceMapping is specified on Overrided mappings.

Change made to AutoMapper.MapInheritanceTree as AutoMappings is not using Visitor which is executed for FluentMappings.

Two tests added to check if Element class/union-subclass exists.

issue described [here](http://groups.google.com/group/fluent-nhibernate/browse_thread/thread/5674e2bfa31f55f1)
