### PR TITLE
Fix for issue #216 - override scanning mishandles abstract overrides 

### DIFF
--- a/src/FluentNHibernate.Testing/AutoMapping/Overrides/AutoMappingOverrideAlterationTests.cs
+++ b/src/FluentNHibernate.Testing/AutoMapping/Overrides/AutoMappingOverrideAlterationTests.cs
@@ -40,5 +40,17 @@ namespace FluentNHibernate.Testing.AutoMapping.Overrides
             new AutoMappingTester<Baz>(model)
                 .Element("class/property[@name='Name']").Exists();
         }
+
+		[Test]
+		public void OverridesCanBeAbstract()
+		{
+			var model = AutoMap.AssemblyOf<Qux>()
+				.Where(t => t.Namespace == typeof(Qux).Namespace);
+
+			alteration.Alter(model);
+
+			new AutoMappingTester<Qux>(model)
+				.Element("class").HasAttribute("batch-size", "10");
+		}
     }
 }

--- a/src/FluentNHibernate.Testing/Fixtures/AutoMappingAlterations/AbstractOverride.cs
+++ b/src/FluentNHibernate.Testing/Fixtures/AutoMappingAlterations/AbstractOverride.cs
@@ -1,0 +1,13 @@
+﻿using FluentNHibernate.Automapping;
+using FluentNHibernate.Automapping.Alterations;
+
+namespace FluentNHibernate.Testing.Fixtures.AutoMappingAlterations
+{
+	public abstract class AbstractOveride<T> : IAutoMappingOverride<T>
+	{
+		public void Override(AutoMapping<T> mapping)
+		{
+			mapping.BatchSize(10);
+		}
+	}
+}

--- a/src/FluentNHibernate.Testing/Fixtures/AutoMappingAlterations/AbstractOverrideImplementation.cs
+++ b/src/FluentNHibernate.Testing/Fixtures/AutoMappingAlterations/AbstractOverrideImplementation.cs
@@ -1,0 +1,9 @@
+﻿using FluentNHibernate.Testing.Fixtures.AutoMappingAlterations.Model;
+
+namespace FluentNHibernate.Testing.Fixtures.AutoMappingAlterations
+{
+	public class AbstractOverrideImplementation : AbstractOveride<Qux>
+	{
+
+	}
+}

--- a/src/FluentNHibernate.Testing/Fixtures/AutoMappingAlterations/Model/Qux.cs
+++ b/src/FluentNHibernate.Testing/Fixtures/AutoMappingAlterations/Model/Qux.cs
@@ -1,0 +1,8 @@
+﻿namespace FluentNHibernate.Testing.Fixtures.AutoMappingAlterations.Model
+{
+	public class Qux
+	{
+		public virtual int Id { get; set; }
+		public virtual string Name { get; set; }
+	}
+}

--- a/src/FluentNHibernate.Testing/FluentNHibernate.Testing.csproj
+++ b/src/FluentNHibernate.Testing/FluentNHibernate.Testing.csproj
@@ -123,6 +123,9 @@
     <Compile Include="AutoMapping\Overrides\ParentOverridesWithSubclasses.cs" />
     <Compile Include="AutoMapping\UnionSubclassConventionTests.cs" />
     <Compile Include="AutoMapping\UnionSubclassTests.cs" />
+    <Compile Include="Fixtures\AutoMappingAlterations\AbstractOverride.cs" />
+    <Compile Include="Fixtures\AutoMappingAlterations\AbstractOverrideImplementation.cs" />
+    <Compile Include="Fixtures\AutoMappingAlterations\Model\Qux.cs" />
     <Compile Include="StubTypeSource.cs" />
     <Compile Include="AutoMapping\TestFixtures.cs" />
     <Compile Include="Cfg\Db\DB2ConfigurationTester.cs" />

--- a/src/FluentNHibernate/Automapping/Alterations/AutoMappingOverrideAlteration.cs
+++ b/src/FluentNHibernate/Automapping/Alterations/AutoMappingOverrideAlteration.cs
@@ -34,6 +34,7 @@ namespace FluentNHibernate.Automapping.Alterations
         {
             // find all types deriving from IAutoMappingOverride<T>
             var types = from type in assembly.GetExportedTypes()
+						where !type.IsAbstract
                         let entity = (from interfaceType in type.GetInterfaces()
                                       where interfaceType.IsGenericType && interfaceType.GetGenericTypeDefinition() == typeof(IAutoMappingOverride<>)
                                       select interfaceType.GetGenericArguments()[0]).FirstOrDefault()


### PR DESCRIPTION
Fix for:

http://fluentnhibernate.lighthouseapp.com/projects/33236-fnh/tickets/216-override-scanning-seems-to-try-to-instantiate-abstract-classes
