### PR TITLE
added convenience for adding filters to automaps

### DIFF
--- a/src/FluentNHibernate/Automapping/AutoPersistenceModel.cs
+++ b/src/FluentNHibernate/Automapping/AutoPersistenceModel.cs
@@ -293,6 +293,12 @@ namespace FluentNHibernate.Automapping
             return this;
         }
 
+		public AutoPersistenceModel AddFilter<TFilter>() where TFilter : IFilterDefinition
+		{
+    		Add(typeof(TFilter));
+			return this;
+		}
+
         internal void AddOverride(Type type, Action<object> action)
         {
             inlineOverrides.Add(new InlineOverride(type, action));


### PR DESCRIPTION
Combining filters with automapping is a bit awkward. See, for example, this SO question:

http://stackoverflow.com/questions/5728935/property-filter-with-fluent-nhibernate-automapping/6538285

It would be easier to say:

```
.Mappings(m => m.AutoMappings.Add(AutoMap.AssemblyOf<Domain.Entity>(cfg) 
            .AddFilter<DateFilter>());
```

So I added that method. It's pure convenience, so I didn't add a test, but let me know if you think one's needed.
