### PR TITLE
Moved ability to add overrides by type to the AutoPersistenceModel

### DIFF
--- a/src/FluentNHibernate/Automapping/Alterations/AutoMappingOverrideAlteration.cs
+++ b/src/FluentNHibernate/Automapping/Alterations/AutoMappingOverrideAlteration.cs
@@ -33,37 +33,17 @@ namespace FluentNHibernate.Automapping.Alterations
         public void Alter(AutoPersistenceModel model)
         {
             // find all types deriving from IAutoMappingOverride<T>
-            var types = from type in assembly.GetExportedTypes()
-                        let entity = (from interfaceType in type.GetInterfaces()
-                                      where interfaceType.IsGenericType && interfaceType.GetGenericTypeDefinition() == typeof(IAutoMappingOverride<>)
-                                      select interfaceType.GetGenericArguments()[0]).FirstOrDefault()
-                        where entity != null
-                        select new { OverrideType = type, EntityType = entity };
+        	var types = from type in assembly.GetExportedTypes()
+        	            let entity = (from interfaceType in type.GetInterfaces()
+        	                          where interfaceType.IsGenericType && interfaceType.GetGenericTypeDefinition() == typeof(IAutoMappingOverride<>)
+        	                          select interfaceType.GetGenericArguments()[0]).FirstOrDefault()
+        	            where entity != null
+        	            select type;
 
-            foreach (var typeMatch in types)
+            foreach (var type in types)
             {
-                var mappingOverride = Activator.CreateInstance(typeMatch.OverrideType);
-                var autoMapType = typeof(AutoMapping<>).MakeGenericType(typeMatch.EntityType);
-                var mapping = (IMappingProvider)Activator.CreateInstance(autoMapType, new List<Member>());
-
-                // HACK: call the Override method with the generic AutoMapping<T>
-                var overrideMethod = typeMatch.OverrideType
-                    .GetMethod("Override");
-
-                GetType()
-                    .GetMethod("AddOverride", BindingFlags.Instance | BindingFlags.NonPublic)
-                    .MakeGenericMethod(typeMatch.EntityType)
-                    .Invoke(this, new[] { model, typeMatch.EntityType, mappingOverride });
+            	model.Override(type);
             }
-        }
-
-        private void AddOverride<T>(AutoPersistenceModel model, Type entity, IAutoMappingOverride<T> mappingOverride)
-        {
-            model.AddOverride(entity, x =>
-            {
-                if (x is AutoMapping<T>)
-                    mappingOverride.Override((AutoMapping<T>)x);
-            });
         }
     }
 }

--- a/src/FluentNHibernate/Automapping/AutoPersistenceModel.cs
+++ b/src/FluentNHibernate/Automapping/AutoPersistenceModel.cs
@@ -315,6 +315,39 @@ namespace FluentNHibernate.Automapping
             return this;
         }
 
+		/// <summary>
+		/// Adds an IAutoMappingOverride reflectively
+		/// </summary>
+		/// <param name="overrideType">Override type, expected to be an IAutoMappingOverride</param>
+		public void Override(Type overrideType)
+		{
+			Type overrideInterface = overrideType.GetInterfaces()
+				.Where(x => x.IsGenericType && x.GetGenericTypeDefinition() == typeof(IAutoMappingOverride<>) && x.GetGenericArguments().Length > 0)
+				.FirstOrDefault();
+			if (overrideInterface != null)
+			{
+				Type entityType = overrideInterface.GetGenericArguments().First();
+				Type autoMappingType = typeof(AutoMapping<>).MakeGenericType(entityType);
+				AddOverride(entityType, x =>
+				{
+					if (x.GetType().IsAssignableFrom(autoMappingType))
+					{
+						var overrideInstance = Activator.CreateInstance(overrideType);
+						GetType()
+							.GetMethod("OverrideHelper", BindingFlags.NonPublic | BindingFlags.Instance)
+							.MakeGenericMethod(entityType)
+							.Invoke(this, new [] {x, overrideInstance});
+					}
+				});
+			}
+		}
+
+		//called reflectively from method above
+		private void OverrideHelper<T>(AutoMapping<T> x, IAutoMappingOverride<T> mappingOverride)
+		{
+			mappingOverride.Override(x);
+		}
+
         /// <summary>
         /// Override all mappings.
         /// </summary>


### PR DESCRIPTION
I came across having to do my own specialized override scanning (long story). Unlike filters, it wasn't easy to simply add IAutoMapOverrides by type; the logic for doing that was hidden in the override scanner. This fix moves it to the AutoPersistenceModel so everyone can use it.

And don't let the branch name fool you; it's just as ugly and reflective as it was before.
