### PR TITLE
FIX for : https://github.com/jagregory/fluent-nhibernate/issues/45

### DIFF
--- a/src/FluentNHibernate/Cfg/FluentMappingsContainer.cs
+++ b/src/FluentNHibernate/Cfg/FluentMappingsContainer.cs
@@ -127,6 +127,8 @@ namespace FluentNHibernate.Cfg
                 model.Add(type);
             }
 
+			model.Conventions.Merge(conventionFinder);
+
             if (!string.IsNullOrEmpty(exportPath))
                 model.WriteMappingsTo(exportPath);
 
@@ -135,8 +137,6 @@ namespace FluentNHibernate.Cfg
 
             if (biDirectionalManyToManyPairer != null)
                 model.BiDirectionalManyToManyPairer = biDirectionalManyToManyPairer;
-
-            model.Conventions.Merge(conventionFinder);
         }
     }
 }


### PR DESCRIPTION
Moved the conventions merge call above the export mappings calls to ensure that conventions are applied before mappings are exported/built.
