### PR TITLE
Added generic version of `ChildWhere` for many-to-many part.

### DIFF
--- a/src/FluentNHibernate.Testing/FluentInterfaceTests/ManyToManyMutablePropertyModelGenerationTests.cs
+++ b/src/FluentNHibernate.Testing/FluentInterfaceTests/ManyToManyMutablePropertyModelGenerationTests.cs
@@ -273,6 +273,14 @@ namespace FluentNHibernate.Testing.FluentInterfaceTests
         }
 
         [Test]
+        public void GenericChildWhereShouldSetAttributeOnRelationshipModel()
+        {
+            ManyToMany(x => x.BagOfChildren)
+                .Mapping(m => m.ChildWhere(x => x.Name == "Name"))
+                .ModelShouldMatch(x => ((ManyToManyMapping)x.Relationship).Where.ShouldEqual("Name = 'Name'"));
+        }
+
+        [Test]
         public void EntityNameShouldSetModelValue()
         {
             ManyToMany(x => x.BagOfChildren)

--- a/src/FluentNHibernate.Testing/FluentInterfaceTests/WhereTests.cs
+++ b/src/FluentNHibernate.Testing/FluentInterfaceTests/WhereTests.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using FluentNHibernate.Mapping;
-using FluentNHibernate.Testing.DomainModel.Mapping;
 using NUnit.Framework;
 
 namespace FluentNHibernate.Testing.FluentInterfaceTests

--- a/src/FluentNHibernate/Mapping/ManyToManyPart.cs
+++ b/src/FluentNHibernate/Mapping/ManyToManyPart.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq.Expressions;
 using FluentNHibernate.Mapping.Providers;
 using FluentNHibernate.MappingModel;
 using FluentNHibernate.MappingModel.Collections;
+using FluentNHibernate.Utils;
 
 namespace FluentNHibernate.Mapping
 {
@@ -325,6 +327,17 @@ namespace FluentNHibernate.Mapping
         {
             relationshipAttributes.Set("Where", Layer.UserSupplied, where);
             return this;
+        }
+
+        /// <summary>
+        /// Sets the where clause for this relationship, on the many-to-many element.
+        /// Note: This only supports simple cases, use the string overload for more complex clauses.
+        /// </summary>
+        public ManyToManyPart<TChild> ChildWhere(Expression<Func<TChild, bool>> where)
+        {
+            var sql = ExpressionToSql.Convert(where);
+
+            return ChildWhere(sql);
         }
 
         protected override CollectionMapping GetCollectionMapping()

--- a/src/FluentNHibernate/Mapping/OneToManyPart.cs
+++ b/src/FluentNHibernate/Mapping/OneToManyPart.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using FluentNHibernate.MappingModel;
 using FluentNHibernate.MappingModel.Collections;
+using FluentNHibernate.Utils;
 
 namespace FluentNHibernate.Mapping
 {
@@ -216,6 +218,17 @@ namespace FluentNHibernate.Mapping
         {
             if (!(childType.IsGenericType && childType.GetGenericTypeDefinition() == typeof(IDictionary<,>)))
                 throw new ArgumentException(member.Name + " must be of type IDictionary<> to be used in a ternary assocation. Type was: " + childType);
+        }
+
+        /// <summary>
+        /// Sets the where clause for this one-to-many relationship.
+        /// Note: This only supports simple cases, use the string overload for more complex clauses.
+        /// </summary>
+        public OneToManyPart<TChild> Where(Expression<Func<TChild, bool>> where)
+        {
+            var sql = ExpressionToSql.Convert(where);
+
+            return Where(sql);
         }
     }
 }

--- a/src/FluentNHibernate/Mapping/ToManyBase.cs
+++ b/src/FluentNHibernate/Mapping/ToManyBase.cs
@@ -539,17 +539,6 @@ namespace FluentNHibernate.Mapping
 
         /// <summary>
         /// Sets the where clause for this one-to-many relationship.
-        /// Note: This only supports simple cases, use the string overload for more complex clauses.
-        /// </summary>
-        public T Where(Expression<Func<TChild, bool>> where)
-        {
-            var sql = ExpressionToSql.Convert(where);
-
-            return Where(sql);
-        }
-
-        /// <summary>
-        /// Sets the where clause for this one-to-many relationship.
         /// </summary>
         public T Where(string where)
         {


### PR DESCRIPTION
Generic version of `Where` method moved from `ToManyBase` into one-to-many part, because on many-to-many part produces incorrect SQL (trying to access column on reference table instead of child table).

Added generic version of `ChildWhere` for many-to-many part.
