### PR TITLE
added ability to set a custom type on composite keys

### DIFF
--- a/src/FluentNHibernate.Testing/AutoMapping/Overrides/CompositeIdOverrides.cs
+++ b/src/FluentNHibernate.Testing/AutoMapping/Overrides/CompositeIdOverrides.cs
@@ -1,5 +1,8 @@
+using System;
 using System.Linq;
 using FluentNHibernate.Automapping;
+using FluentNHibernate.Mapping;
+using FluentNHibernate.MappingModel.Identity;
 using NUnit.Framework;
 
 namespace FluentNHibernate.Testing.AutoMapping.Overrides
@@ -38,6 +41,60 @@ namespace FluentNHibernate.Testing.AutoMapping.Overrides
 
             classMapping.References.ShouldNotContain(x => x.Name == "Child");
         }
+
+		[Test]
+    	public void ShouldMapEnumIdAsAString()
+		{
+			var model = AutoMap.Source(new StubTypeSource(new[] {typeof(CompositeIdEntityWithEnum)}))
+				.Override<CompositeIdEntityWithEnum>(o =>
+					o.CompositeId()
+						.KeyProperty(x => x.FirstId)
+						.KeyProperty(x => x.SecondId));
+
+
+			VerifyMapping(model, idMap =>
+			{
+				var firstKey = idMap.Keys.First();
+
+				//this part is dumb because i'm asserting a specific implementation. i don't have any other way
+				//of getting to the key type though
+				firstKey.ShouldBeOfType(typeof(KeyPropertyMapping));
+				var keyProp = (KeyPropertyMapping)firstKey;
+				keyProp.Type.GetUnderlyingSystemType().ShouldEqual(typeof(GenericEnumMapper<>).MakeGenericType(typeof(SomeEnum)));
+			});
+		}
+
+		[Test]
+		public void ShouldMapEnumIdAsOverridenType()
+		{
+			var model = AutoMap.Source(new StubTypeSource(new[] { typeof(CompositeIdEntityWithEnum) }))
+				.Override<CompositeIdEntityWithEnum>(o =>
+					o.CompositeId()
+						.KeyProperty(x => x.FirstId).CustomType<SomeEnum>()
+						.KeyProperty(x => x.SecondId).CustomType<SomeEnum>());
+
+
+			VerifyMapping(model, idMap =>
+			{
+				var firstKey = idMap.Keys.First();
+				firstKey.ShouldBeOfType(typeof(KeyPropertyMapping));
+				var firstKeyProp = (KeyPropertyMapping)firstKey;
+				firstKeyProp.Type.GetUnderlyingSystemType().ShouldEqual(typeof(SomeEnum));
+			});
+		}
+
+		private void VerifyMapping(AutoPersistenceModel model, Action<CompositeIdMapping> verifier)
+		{
+			var idMapping = model.BuildMappings()
+								.First()
+								.Classes
+								.First()
+								.Id
+								;
+
+			idMapping.ShouldBeOfType(typeof(CompositeIdMapping));
+			verifier((CompositeIdMapping)idMapping);
+		}
     }
 
     internal class CompositeIdEntity
@@ -46,4 +103,16 @@ namespace FluentNHibernate.Testing.AutoMapping.Overrides
         public int SecondId { get; set; }
         public Child Child { get; set; }
     }
+
+	internal class CompositeIdEntityWithEnum
+	{
+		public SomeEnum FirstId { get; set; }
+		public SomeEnum SecondId { get; set; }
+	}
+
+	internal enum SomeEnum
+	{
+		PossiblityOne,
+		PossibilityTwo
+	}
 }

--- a/src/FluentNHibernate/Mapping/CompositeIdentityPart.cs
+++ b/src/FluentNHibernate/Mapping/CompositeIdentityPart.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Linq.Expressions;
 using FluentNHibernate.Mapping.Providers;
 using FluentNHibernate.MappingModel;
@@ -160,6 +161,16 @@ namespace FluentNHibernate.Mapping
 
             return this;
         }
+
+		public virtual CompositeIdentityPart<T> CustomType<CType>()
+		{
+			var key = keys.Where(x => x is KeyPropertyMapping).Cast<KeyPropertyMapping>().LastOrDefault();
+			if (key != null)
+			{
+				key.Set(x => x.Type, Layer.Defaults, new TypeReference(typeof(CType)));
+			}
+			return this;
+		}
 
 		/// <summary>
 		/// Set the access and naming strategy for this identity.


### PR DESCRIPTION
I had a situation where one property in my composite key was an enum that I needed mapped as an integer. There wasn't a way to do that from my override, so I added it.

``` ruby
CompositeId()
   .KeyProperty(x => x.Id)
   .KeyProperty(x => x.SomeOtherProperty).CustomType<SomeEnum>()
```

I actually don't think my fix is very good. `CompositeIdentityPart.KeyProperty()` returns a `CompositeIdentityPart`, so there's no explicit way to get the `KeyPropertyMapping` object. So what I did was make `CustomType()` just track down the last key property added. That works fine if it's used as intended but acts stupidly if misused. For example:

``` ruby
CompositeId()
   .KeyProperty(x => x.SomeProperty)
   .KeyReference(x => x.Child).CustomType<SomeEnum>()
```

That makes no sense and in my implementation will apply the `SomeEnum` type to `SomeProperty`. One alternative would be to create a `KeyProperty(Expression<Func<T, object>> expression, Action<KeyProperty> modifyKeyProperty)` overload. What do you think?
