### PR TITLE
Fix performance issue searching in list of 'availableTypes'. GetLogicalPa

### DIFF
--- a/src/FluentNHibernate/Automapping/AutoMapper.cs
+++ b/src/FluentNHibernate/Automapping/AutoMapper.cs
@@ -121,22 +121,22 @@ namespace FluentNHibernate.Automapping
             var excludedTypes = mappingTypes
                 .Where(x => cfg.IsConcreteBaseType(x.Type.BaseType))
                 .ToArray();
-            var availableTypes = mappingTypes.Except(excludedTypes);
+            var availableTypes = mappingTypes.Except(excludedTypes).ToDictionary(x => x.Type);
             var mappingTypesWithLogicalParents = new Dictionary<AutoMapType, AutoMapType>();
 
             foreach (var type in availableTypes)
-                mappingTypesWithLogicalParents.Add(type, GetLogicalParent(type.Type, availableTypes));
+                mappingTypesWithLogicalParents.Add(type.Value, GetLogicalParent(type.Key, availableTypes));
             return mappingTypesWithLogicalParents;
         }
 
-        static AutoMapType GetLogicalParent(Type type, IEnumerable<AutoMapType> availableTypes)
+        static AutoMapType GetLogicalParent(Type type, IDictionary<Type, AutoMapType> availableTypes)
         {
             if (type.BaseType == typeof(object) || type.BaseType == null)
                 return null;
 
-            var baseType = availableTypes.FirstOrDefault(x => x.Type == type.BaseType);
+            AutoMapType baseType;
 
-            if (baseType != null)
+            if (availableTypes.TryGetValue(type.BaseType, out baseType))
                 return baseType;
 
             return GetLogicalParent(type.BaseType, availableTypes);


### PR DESCRIPTION
Fix performance issue searching in list of 'availableTypes'. GetLogicalParent would be called n^2 times at worst.

I was having major performances issues when the number of entities was increasing. For 223 entities, start up time for the application (including session factory) would take up to 50 seconds. This only happened when using auto mapping, and not using hbm mappings.

The critical method was quickly found using ANTS Performance Profiler. The method GetLogicalParent was called 223^2=49729 times, and the method was searching a list linearly over the same 223 types.

After applying this fix, the start up time of my application was reduced to 25 seconds. All Fluent NHibernate tests still pass.
