### PR TITLE
Added ability to set key as (not)nullable via convention

### DIFF
--- a/src/FluentNHibernate.Testing/ConventionsTests/ApplyingToModel/HasManyCollectionConventionTests.cs
+++ b/src/FluentNHibernate.Testing/ConventionsTests/ApplyingToModel/HasManyCollectionConventionTests.cs
@@ -193,6 +193,22 @@ namespace FluentNHibernate.Testing.ConventionsTests.ApplyingToModel
         }
 
         [Test]
+        public void KeyNullableShouldSetModelValue()
+        {
+            Convention(x => x.KeyNullable());
+
+            VerifyModel(x => x.Key.NotNull.ShouldBeFalse());
+        }
+
+        [Test]
+        public void KeyNotNullableShouldSetModelValue()
+        {
+            Convention(x => x.Not.KeyNullable());
+
+            VerifyModel(x => x.Key.NotNull.ShouldBeTrue());
+        }
+
+        [Test]
         public void ShouldSetTableNameProperty()
         {
             Convention(x => x.Table("xxx"));

--- a/src/FluentNHibernate/Conventions/Instances/CollectionInstance.cs
+++ b/src/FluentNHibernate/Conventions/Instances/CollectionInstance.cs
@@ -122,6 +122,12 @@ namespace FluentNHibernate.Conventions.Instances
             mapping.Set(x => x.Subselect, Layer.Conventions, subselect);
         }
 
+        public void KeyNullable()
+        {
+            mapping.Key.Set(x => x.NotNull, Layer.Conventions, !nextBool);
+            nextBool = true;
+        }
+
         public void Table(string tableName)
         {
             mapping.Set(x => x.TableName, Layer.Conventions, tableName);

--- a/src/FluentNHibernate/Conventions/Instances/ICollectionInstance.cs
+++ b/src/FluentNHibernate/Conventions/Instances/ICollectionInstance.cs
@@ -43,5 +43,6 @@ namespace FluentNHibernate.Conventions.Instances
         new void OrderBy(string orderBy);
         new void Sort(string sort);
         void Subselect(string subselect);
+        void KeyNullable();
     }
 }


### PR DESCRIPTION
```
    public class HasManyConvention : IHasManyConvention
    {
        public void Apply(IOneToManyCollectionInstance instance)
        {
            instance.Not.Inverse();
            instance.Not.KeyNullable();
        }
    }
```

This is useful for uni-directional one-to-many mapping. "not-inverse" on one-to-many and "not-null" on key prevents update after insert on foreign key column.
