### PR TITLE
Fixed Formula with ManyToOne

### DIFF
--- a/src/FluentNHibernate.Testing/DomainModel/Mapping/ManyToOneTester.cs
+++ b/src/FluentNHibernate.Testing/DomainModel/Mapping/ManyToOneTester.cs
@@ -162,5 +162,18 @@ namespace FluentNHibernate.Testing.DomainModel.Mapping
                         .Not.LazyLoad().Not.Nullable())
                 .Element("class/many-to-one/column").HasAttribute("not-null", "true");
         }
+
+        [Test]
+        public void ManyToOneFormulaShouldSetFormulaAndNotRenderColumn()
+        {
+            new MappingTester<MappedObject>()
+                .ForMapping(map =>
+                {
+                    map.References(x => x.Parent)
+                        .Formula("foo(bar)");
+                })
+                .Element("class/many-to-one").HasAttribute("formula", "foo(bar)")
+                .Element("class/many-to-one/column").DoesntExist();
+        }
     }
 }

--- a/src/FluentNHibernate/Mapping/ManyToOnePart.cs
+++ b/src/FluentNHibernate/Mapping/ManyToOnePart.cs
@@ -353,7 +353,7 @@ namespace FluentNHibernate.Mapping
             mapping.Set(x => x.Name, Layer.Defaults, member.Name);
             mapping.Set(x => x.Class, Layer.Defaults, new TypeReference(typeof(TOther)));
 
-            if (columns.Count == 0)
+            if (columns.Count == 0 && !mapping.IsSpecified("Formula"))
                 mapping.AddColumn(Layer.Defaults, CreateColumn(member.Name + "_id"));
 
             foreach (var column in columns)


### PR DESCRIPTION
Currently when Formula is used in ManyToOne - mapping for column is generated, which breaks the mapping.
Fix and test is included in this request (It's same as in PropertyPart.)
