### PR TITLE
Added OtherSide property to one-to-many

### DIFF
--- a/src/FluentNHibernate/Conventions/Inspections/IOneToManyCollectionInspector.cs
+++ b/src/FluentNHibernate/Conventions/Inspections/IOneToManyCollectionInspector.cs
@@ -3,5 +3,7 @@ namespace FluentNHibernate.Conventions.Inspections
     public interface IOneToManyCollectionInspector : ICollectionInspector
     {
         new IOneToManyInspector Relationship { get; }
+
+        IManyToOneInspector OtherSide { get; }
     }
 }

--- a/src/FluentNHibernate/Conventions/Instances/IOneToManyCollectionInstance.cs
+++ b/src/FluentNHibernate/Conventions/Instances/IOneToManyCollectionInstance.cs
@@ -11,6 +11,8 @@ namespace FluentNHibernate.Conventions.Instances
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         new IOneToManyCollectionInstance Not { get; }
 
+        new IManyToOneInstance OtherSide { get; }
+
         /// <summary>
         /// Applies a filter to this relationship given its name.
         /// </summary>

--- a/src/FluentNHibernate/Conventions/Instances/ManyToManyCollectionInstance.cs
+++ b/src/FluentNHibernate/Conventions/Instances/ManyToManyCollectionInstance.cs
@@ -35,10 +35,11 @@ namespace FluentNHibernate.Conventions.Instances
         {
             get
             {
-                if (mapping.OtherSide == null || !(mapping.OtherSide is CollectionMapping))
+                var otherSide = mapping.OtherSide as CollectionMapping;
+                if (otherSide == null)
                     return null;
 
-                return new ManyToManyCollectionInstance((CollectionMapping)mapping.OtherSide);
+                return new ManyToManyCollectionInstance(otherSide);
             }
         }
 
@@ -46,6 +47,7 @@ namespace FluentNHibernate.Conventions.Instances
         {
             get { return new ManyToManyInstance((ManyToManyMapping)mapping.Relationship); }
         }
+
         public new Type ChildType
         {
             get { return mapping.ChildType; }

--- a/src/FluentNHibernate/Conventions/Instances/OneToManyCollectionInstance.cs
+++ b/src/FluentNHibernate/Conventions/Instances/OneToManyCollectionInstance.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using FluentNHibernate.Conventions.Inspections;
+using FluentNHibernate.MappingModel;
 using FluentNHibernate.MappingModel.Collections;
 
 namespace FluentNHibernate.Conventions.Instances
@@ -18,6 +19,23 @@ namespace FluentNHibernate.Conventions.Instances
         IOneToManyInspector IOneToManyCollectionInspector.Relationship
         {
             get { return Relationship; }
+        }
+
+        IManyToOneInspector IOneToManyCollectionInspector.OtherSide
+        {
+            get { return OtherSide; }
+        }
+
+        public IManyToOneInstance OtherSide
+        {
+            get
+            {
+                var otherSide = mapping.OtherSide as ManyToOneMapping;
+                if (otherSide == null)
+                    return null;
+
+                return new ManyToOneInstance(otherSide);
+            }
         }
 
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]


### PR DESCRIPTION
Added OtherSide property to IOneToManyCollectionInspector and IOneToManyCollectionInstance

This would be useful to determine is one-to-many relationship is uni- or bi-directional. 

http://stackoverflow.com/questions/7601107/check-if-one-to-many-relationship-is-uni-or-bi-directional-in-convention
