### PR TITLE
Fix for issue #104

### DIFF
--- a/src/FluentNHibernate.Testing/AutoMapping/Apm/AutoPersistenceModelTests.cs
+++ b/src/FluentNHibernate.Testing/AutoMapping/Apm/AutoPersistenceModelTests.cs
@@ -10,7 +10,7 @@ using ExampleClass=FluentNHibernate.Automapping.TestFixtures.ExampleClass;
 namespace FluentNHibernate.Testing.AutoMapping.Apm
 {
     [TestFixture]
-    public partial class AutoPersistenceModelTests : BaseAutoPersistenceTests
+    public partial class AutoPersistenceModelTests
     {
         [Test]
         public void CanSearchForOpenGenericTypes()

--- a/src/FluentNHibernate.Testing/AutoMapping/Overrides/ReferenceComponentOverrides.cs
+++ b/src/FluentNHibernate.Testing/AutoMapping/Overrides/ReferenceComponentOverrides.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using FluentNHibernate.Automapping;
+using NUnit.Framework;
+
+namespace FluentNHibernate.Testing.AutoMapping.Overrides
+{
+    public class ReferenceComponentOverrides
+    {
+        [Test]
+        public void should_be_able_to_build_mapping()
+        {
+            var source = new StubTypeSource(typeof(IncomingDocument), typeof(DocumentNumber));
+
+            var persistenceModel = AutoMap.Source(source, new AutomappingConfiguration())
+                .Override<IncomingDocument>(m => m.Component(x => x.IncomingNumber)
+                    .ColumnPrefix("INCOMING_"));
+
+            Assert.DoesNotThrow(() => persistenceModel.BuildMappings());
+        }
+
+        class AutomappingConfiguration : DefaultAutomappingConfiguration
+        {
+            public override bool IsComponent(Type type)
+            {
+                return type == typeof(DocumentNumber);
+            }
+
+            public override bool ShouldMap(Type type)
+            {
+                return type == typeof(IncomingDocument);
+            }
+        }
+
+        class DocumentNumber
+        {}
+
+        class IncomingDocument
+        {
+            public virtual int Id { get; set; }
+            public virtual DocumentNumber IncomingNumber { get; set; }
+        }
+    }
+}

--- a/src/FluentNHibernate.Testing/FluentNHibernate.Testing.csproj
+++ b/src/FluentNHibernate.Testing/FluentNHibernate.Testing.csproj
@@ -101,6 +101,7 @@
     <Compile Include="AutoMapping\Apm\AlterationTests.cs" />
     <Compile Include="AutoMapping\Apm\ConcreteBaseClassTests.cs" />
     <Compile Include="AutoMapping\Apm\Conventions\VersionConventionTests.cs" />
+    <Compile Include="AutoMapping\Overrides\ReferenceComponentOverrides.cs" />
     <Compile Include="AutoMapping\Overrides\AutoMappingOverrideAlterationTests.cs" />
     <Compile Include="AutoMapping\Apm\CacheOverrideTests.cs" />
     <Compile Include="AutoMapping\Apm\Conventions\HasManyConventionTests.cs" />

--- a/src/FluentNHibernate/Automapping/AutoMapping.cs
+++ b/src/FluentNHibernate/Automapping/AutoMapping.cs
@@ -40,10 +40,9 @@ namespace FluentNHibernate.Automapping
         {
             mapping.MergeAttributes(attributes.Clone());
 
-            if (mapping is ClassMapping)
+            var classMapping = mapping as ClassMapping;
+            if (classMapping != null)
             {
-                var classMapping = (ClassMapping)mapping;
-
                 if (providers.Id != null)
                     classMapping.Set(x => x.Id, Layer.Defaults, providers.Id.GetIdentityMapping());
 
@@ -129,8 +128,8 @@ namespace FluentNHibernate.Automapping
             return this;
         }
 
-		public AutoJoinedSubClassPart<TSubclass> JoinedSubClass<TSubclass>(string keyColumn, Action<AutoJoinedSubClassPart<TSubclass>> action)
-			where TSubclass : T
+        public AutoJoinedSubClassPart<TSubclass> JoinedSubClass<TSubclass>(string keyColumn, Action<AutoJoinedSubClassPart<TSubclass>> action)
+            where TSubclass : T
         {
             var genericType = typeof(AutoJoinedSubClassPart<>).MakeGenericType(typeof(TSubclass));
             var joinedclass = (AutoJoinedSubClassPart<TSubclass>)Activator.CreateInstance(genericType, keyColumn);
@@ -140,7 +139,7 @@ namespace FluentNHibernate.Automapping
 
             providers.Subclasses[typeof(TSubclass)] = joinedclass;
 
-		    return joinedclass;
+            return joinedclass;
         }
 
         public IAutoClasslike JoinedSubClass(Type type, string keyColumn)
@@ -155,31 +154,31 @@ namespace FluentNHibernate.Automapping
         }
 
         public AutoJoinedSubClassPart<TSubclass> JoinedSubClass<TSubclass>(string keyColumn)
-			where TSubclass : T
-		{
-			return JoinedSubClass<TSubclass>(keyColumn, null);
-		}
+            where TSubclass : T
+        {
+            return JoinedSubClass<TSubclass>(keyColumn, null);
+        }
 
-		public AutoSubClassPart<TSubclass> SubClass<TSubclass>(object discriminatorValue, Action<AutoSubClassPart<TSubclass>> action)
-			where TSubclass : T
+        public AutoSubClassPart<TSubclass> SubClass<TSubclass>(object discriminatorValue, Action<AutoSubClassPart<TSubclass>> action)
+            where TSubclass : T
         {
             var genericType = typeof(AutoSubClassPart<>).MakeGenericType(typeof(TSubclass));
             var subclass = (AutoSubClassPart<TSubclass>)Activator.CreateInstance(genericType, null, discriminatorValue);
-            
+
             if (action != null)
                 action(subclass);
 
             // remove any mappings for the same type, then re-add
             providers.Subclasses[typeof(TSubclass)] = subclass;
 
-		    return subclass;
+            return subclass;
         }
 
         public AutoSubClassPart<TSubclass> SubClass<TSubclass>(object discriminatorValue)
-			where TSubclass : T
-		{
-			return SubClass<TSubclass>(discriminatorValue, null);
-		}
+            where TSubclass : T
+        {
+            return SubClass<TSubclass>(discriminatorValue, null);
+        }
 
         public IAutoClasslike SubClass(Type type, string discriminatorValue)
         {
@@ -191,10 +190,10 @@ namespace FluentNHibernate.Automapping
 
             return (IAutoClasslike)subclass;
         }
-        
+
         // hide the base one D:
-        private new void Join(string table, Action<JoinPart<T>> action)
-        { }
+        new void Join(string table, Action<JoinPart<T>> action)
+        {}
 
         public void Join(string table, Action<AutoJoinPart<T>> action)
         {

--- a/src/FluentNHibernate/Mapping/ClasslikeMapBase.cs
+++ b/src/FluentNHibernate/Mapping/ClasslikeMapBase.cs
@@ -238,7 +238,14 @@ namespace FluentNHibernate.Mapping
         /// <returns>Component reference builder</returns>
         public virtual ReferenceComponentPart<TComponent> Component<TComponent>(Expression<Func<T, TComponent>> member)
         {
-            var part = new ReferenceComponentPart<TComponent>(member.ToMember(), typeof(T));
+            return Component<TComponent>(member.ToMember());
+        }
+
+        ReferenceComponentPart<TComponent> Component<TComponent>(Member member)
+        {
+            OnMemberMapped(member);
+
+            var part = new ReferenceComponentPart<TComponent>(member, typeof(T));
 
             providers.Components.Add(part);
 
@@ -287,7 +294,7 @@ namespace FluentNHibernate.Mapping
 
             var part = new ComponentPart<TComponent>(typeof(T), member);
 
-            action(part);
+            if (action != null) action(part);
 
             providers.Components.Add(part);
 


### PR DESCRIPTION
Fix for issue #104: 
FNH should mark ReferenceComponent as mapped when it is overridden in IAutoMappingOverride

I've following configuration:

``` csharp
public class AutomappingConfiguration : DefaultAutomappingConfiguration
{
    private readonly HashSet<Type> components = new HashSet<Type>
                                                    {
                                                        typeof (DocumentNumber)
                                                    };


    public override bool IsComponent(Type type)
    {
        return components.Contains(type);
    }

    public override string GetComponentColumnPrefix(FluentNHibernate.Member member)
    {
        //replaces camel case with underscores "IncomingDocument" => "INCOMING_DOCUMENT"
        //and adds undersocre at end
        return string.Format("{0}_", Regex.Replace(member.Name, "([a-z](?=[A-Z])|[A-Z](?=[A-Z][a-z]))", "$1_").ToUpper());
    }

    //rest of configuration
}
```

And alteration for my entity.

``` csharp
public class IncomingDocumentMap : IAutoMappingOverride<IncomingDocument>
{
    public void Override(AutoMapping<IncomingDocument> mapping)
    {
        mapping.Component(x => x.IncomingNumber) //incoming number is type of DocumentNumber
            .ColumnPrefix("INCOMING_"); // I need to override default column prefix for component. 
    }
}
```

When I try to build sesion factory I've got following exeption:

```
System.InvalidOperationException: Tried to add component 'IncomingNumber' when already added.
at FluentNHibernate.MappingModel.MappedMembers.AddComponent(IComponentMapping componentMapping) in d:\Builds\FluentNH\src\FluentNHibernate\MappingModel\MappedMembers.cs: line 133
at FluentNHibernate.Automapping.Steps.ComponentStep.Map(ClassMappingBase classMap, Member member) in d:\Builds\FluentNH\src\FluentNHibernate\Automapping\Steps\ComponentStep.cs: line 26
at FluentNHibernate.Automapping.AutoMapper.TryMapProperty(ClassMappingBase mapping, Member member, IList`1 mappedMembers) in d:\Builds\FluentNH\src\FluentNHibernate\Automapping\AutoMapper.cs: line 170
at FluentNHibernate.Automapping.AutoMapper.<>c__DisplayClasse.<ProcessClass>b__d(Member x) in d:\Builds\FluentNH\src\FluentNHibernate\Automapping\AutoMapper.cs: line 158
at FluentNHibernate.Utils.CollectionExtensions.Each(IEnumerable`1 enumerable, Action`1 each) in d:\Builds\FluentNH\src\FluentNHibernate\Utils\CollectionExtensions.cs: line 15
at FluentNHibernate.Automapping.AutoMapper.ProcessClass(ClassMappingBase mapping, Type entityType, IList`1 mappedMembers) in d:\Builds\FluentNH\src\FluentNHibernate\Automapping\AutoMapper.cs: line 156
at FluentNHibernate.Automapping.AutoMapper.MergeMap(Type classType, ClassMappingBase mapping, IList`1 mappedMembers) in d:\Builds\FluentNH\src\FluentNHibernate\Automapping\AutoMapper.cs: line 43
at FluentNHibernate.Automapping.AutoMapper.Map(Type classType, List`1 types) in d:\Builds\FluentNH\src\FluentNHibernate\Automapping\AutoMapper.cs: line 186
at FluentNHibernate.Automapping.AutoPersistenceModel.AddMapping(Type type) in d:\Builds\FluentNH\src\FluentNHibernate\Automapping\AutoPersistenceModel.cs: line 209
at FluentNHibernate.Automapping.AutoPersistenceModel.CompileMappings() in d:\Builds\FluentNH\src\FluentNHibernate\Automapping\AutoPersistenceModel.cs: line 173
at FluentNHibernate.Automapping.AutoPersistenceModel.Configure(Configuration configuration) in d:\Builds\FluentNH\src\FluentNHibernate\Automapping\AutoPersistenceModel.cs: line 199
at FluentNHibernate.Cfg.AutoMappingsContainer.Apply(Configuration cfg, PersistenceModel model) in d:\Builds\FluentNH\src\FluentNHibernate\Cfg\AutoMappingsContainer.cs: line 86
at FluentNHibernate.Cfg.MappingConfiguration.Apply(Configuration cfg) in d:\Builds\FluentNH\src\FluentNHibernate\Cfg\MappingConfiguration.cs: line 80
at FluentNHibernate.Cfg.FluentConfiguration.BuildConfiguration() in d:\Builds\FluentNH\src\FluentNHibernate\Cfg\FluentConfiguration.cs: line 249 


FluentNHibernate.Cfg.FluentConfigurationException: An invalid or incomplete configuration was used while creating a SessionFactory. Check PotentialReasons collection, and InnerException for more detail.
at FluentNHibernate.Cfg.FluentConfiguration.BuildConfiguration() in d:\Builds\FluentNH\src\FluentNHibernate\Cfg\FluentConfiguration.cs: line 264
```

If I remove `typeof(DocumentNumber)` from component types I've got exception which says that property is references unmapped class

```
NHibernate.MappingException: An association from the table INCOMING_DOCUMENT refers to an unmapped class: DocumentNumber
at NHibernate.Cfg.Configuration.LogAndThrow(Exception exception)
at NHibernate.Cfg.Configuration.SecondPassCompileForeignKeys(Table table, ISet done)
at NHibernate.Cfg.Configuration.SecondPassCompile()
at NHibernate.Cfg.Configuration.BuildSessionFactory()

```

If I write component with inlined configuration that all works fine:

``` csharp
public class IncomingDocumentMap : IAutoMappingOverride<IncomingDocument>
{
    public void Override(AutoMapping<IncomingDocument> mapping)
    {
        mapping.Component(x => x.IncomingNumber,
                            c =>
                            {
                                c.Map(x => x.Number).Column("INCOMING_NUMBER");
                                c.Map(x => x.Date).Column("INCOMING_DATE");
                            });
     }
}
```
