### PR TITLE
Added cascade.merge option

### DIFF
--- a/src/FluentNHibernate.Testing/ConventionsTests/Inspection/CascadeTests.cs
+++ b/src/FluentNHibernate.Testing/ConventionsTests/Inspection/CascadeTests.cs
@@ -47,5 +47,12 @@ namespace FluentNHibernate.Testing.ConventionsTests.Inspection.ValueTypes
         {
             Cascade.SaveUpdate.ToString().ShouldEqual("save-update");
         }
+
+        [Test]
+        public void MergeShouldHaveCorrectValue()
+        {
+            Cascade.All.ToString().ShouldEqual("merge");
+        }
+
     }
 }

--- a/src/FluentNHibernate.Testing/DomainModel/Mapping/CascadeExpressionTester.cs
+++ b/src/FluentNHibernate.Testing/DomainModel/Mapping/CascadeExpressionTester.cs
@@ -58,5 +58,11 @@ namespace FluentNHibernate.Testing.DomainModel.Mapping
 		{
 			A_call_to(_cascade.Delete).should_set_the_cascade_value_to("delete");
 		}
+
+        [Test]
+        public void Merge_should_add_the_correct_cascade_attribute_to_the_parent_part()
+        {
+            A_call_to(_cascade.Merge).should_set_the_cascade_value_to("merge");
+        }
 	}
 }

--- a/src/FluentNHibernate/Conventions/Helpers/DefaultCascade.cs
+++ b/src/FluentNHibernate/Conventions/Helpers/DefaultCascade.cs
@@ -31,5 +31,13 @@ namespace FluentNHibernate.Conventions.Helpers
                 criteria => { },
                 instance => instance.DefaultCascade.Delete());
         }
+
+
+        public static IHibernateMappingConvention Merge()
+        {
+            return new BuiltHibernateMappingConvention(
+                criteria => { },
+                instance => instance.DefaultCascade.Merge());
+        }
     }
 }

--- a/src/FluentNHibernate/Conventions/Inspections/Cascade.cs
+++ b/src/FluentNHibernate/Conventions/Inspections/Cascade.cs
@@ -8,6 +8,7 @@ namespace FluentNHibernate.Conventions.Inspections
         public static readonly Cascade None = new Cascade("none");
         public static readonly Cascade SaveUpdate = new Cascade("save-update");
         public static readonly Cascade Delete = new Cascade("delete");
+        public static readonly Cascade Merge = new Cascade("merge");
         
         private readonly string value;
 

--- a/src/FluentNHibernate/Conventions/Instances/CascadeInstance.cs
+++ b/src/FluentNHibernate/Conventions/Instances/CascadeInstance.cs
@@ -30,5 +30,10 @@ namespace FluentNHibernate.Conventions.Instances
         {
             setter("delete");
         }
+
+        public void Merge()
+        {
+            setter("merge");
+        }
     }
 }

--- a/src/FluentNHibernate/Conventions/Instances/ICascadeInstance.cs
+++ b/src/FluentNHibernate/Conventions/Instances/ICascadeInstance.cs
@@ -8,5 +8,6 @@ namespace FluentNHibernate.Conventions.Instances
         void None();
         void SaveUpdate();
         void Delete();
+        void Merge();
     }
 }

--- a/src/FluentNHibernate/Mapping/CascadeExpression.cs
+++ b/src/FluentNHibernate/Mapping/CascadeExpression.cs
@@ -48,5 +48,16 @@ namespace FluentNHibernate.Mapping
 			setter("delete");
             return parent;
 		}
+
+        /// <summary>
+        /// Cascade deletes
+        /// </summary>
+        public TParent Merge()
+        {
+            setter("merge");
+            return parent;
+        }
+
+
 	}
 }


### PR DESCRIPTION
I have added the cascade.merge() convention. It is present in nhibernate engine so
changes are only in the interfaces for cascade/cascade instance.
