### PR TITLE
InstallGems.bat - installing right version of albacore

### DIFF
--- a/InstallGems.bat
+++ b/InstallGems.bat
@@ -7,5 +7,5 @@ call gem install rake
 
 call rake setup:ensure_gemcutter_source
 
-echo Installing Albacore v0.1.5 (newer builds bork it!)
-call gem install albacore -v 0.1.5
+echo Installing Albacore
+call gem install albacore


### PR DESCRIPTION
Now RakeFile requires Albacore > 0.2.4, so removed version constraint
