### PR TITLE
Adding MsSqlCe40 dialect configuration option

### DIFF
--- a/src/FluentNHibernate/Cfg/Db/MsSqlCeConfiguration.cs
+++ b/src/FluentNHibernate/Cfg/Db/MsSqlCeConfiguration.cs
@@ -14,5 +14,10 @@ namespace FluentNHibernate.Cfg.Db
         {
             get { return new MsSqlCeConfiguration().Dialect<MsSqlCeDialect>(); }
         }
+
+        public static MsSqlCeConfiguration MsSqlCe40
+        {
+            get { return new MsSqlCeConfiguration().Dialect<MsSqlCe40Dialect>(); }
+        }
     }
 }


### PR DESCRIPTION
Hi,

While working with SqlCe 40 I figured some tests where not passing on my side with Limits (paging). It appeared that the dialect which was used was not MsSqlCe40, as actually it's not available in Fluent.Cfg.Db.MsSqlCeConfiguration. 

So the purpose of this changeset is to add a MsSqlCe40 option, in addition to the current Standard one, that I did let for ascendant compatibility purpose. 

Thanks
Sebastien
