### PR TITLE
Property Formula mapping override fix

### DIFF
--- a/src/FluentNHibernate/MappingModel/PropertyMapping.cs
+++ b/src/FluentNHibernate/MappingModel/PropertyMapping.cs
@@ -20,8 +20,11 @@ namespace FluentNHibernate.MappingModel
         {
             visitor.ProcessProperty(this);
 
-            foreach (var column in Columns)
-                visitor.Visit(column);
+            if (String.IsNullOrEmpty(this.Formula))
+            {
+                foreach (var column in Columns)
+                    visitor.Visit(column);
+            }
         }
 
         public Type ContainingEntityType { get; set; }


### PR DESCRIPTION
Fix Property.Formula mapping override: if a Formula is specified, the Columns collection should be ignored.

Without this, if I use automap+overrides, the property will already have a Column property set, and it will not be possible to overcome this.
