### PR TITLE
fixing #190 - should recognize byte and short as identity

### DIFF
--- a/src/FluentNHibernate.Testing/AutoMapping/Apm/IdentityTests.cs
+++ b/src/FluentNHibernate.Testing/AutoMapping/Apm/IdentityTests.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using FluentNHibernate.Automapping;
+using FluentNHibernate.Testing.Automapping;
+using NUnit.Framework;
+
+namespace FluentNHibernate.Testing.AutoMapping.Apm
+{
+    [TestFixture]
+    public class IdentityTests
+    {
+        [Test]
+        public void CanUseIdentityGeneratorForIntIds()
+        {
+            var autoMapper = AutoMap.Source(new StubTypeSource(typeof(ClassWithIntId)));
+
+            new AutoMappingTester<ClassWithIntId>(autoMapper)
+                .Element("class/id/generator").HasAttribute("class", "identity");
+        }
+
+        [Test]
+        public void CanUseIdentityGeneratorForLongIds()
+        {
+            var autoMapper = AutoMap.Source(new StubTypeSource(typeof(ClassWithLongId)));
+
+            new AutoMappingTester<ClassWithLongId>(autoMapper)
+                .Element("class/id/generator").HasAttribute("class", "identity");
+        }
+
+        [Test]
+        public void CanUseIdentityGeneratorForByteIds()
+        {
+            var autoMapper = AutoMap.Source(new StubTypeSource(typeof(ByteId)));
+
+            new AutoMappingTester<ByteId>(autoMapper)
+                .Element("class/id/generator").HasAttribute("class", "identity");
+        }
+
+        [Test]
+        public void CanUseIdentityGeneratorForShortIds()
+        {
+            var autoMapper = AutoMap.Source(new StubTypeSource(typeof(ShortId)));
+
+            new AutoMappingTester<ShortId>(autoMapper)
+                .Element("class/id/generator").HasAttribute("class", "identity");
+        }
+    }
+
+    class ClassWithIntId
+    {
+        public virtual int Id { get; set; }
+    }
+
+    class ClassWithLongId
+    {
+        public virtual long Id { get; set; }
+    }
+
+    class ByteId
+    {
+        public virtual byte Id { get; set; }
+    }
+
+    class ShortId
+    {
+        public virtual short Id { get; set; }
+    }
+}

--- a/src/FluentNHibernate.Testing/FluentNHibernate.Testing.csproj
+++ b/src/FluentNHibernate.Testing/FluentNHibernate.Testing.csproj
@@ -101,6 +101,7 @@
     <Compile Include="AutoMapping\Apm\AlterationTests.cs" />
     <Compile Include="AutoMapping\Apm\ConcreteBaseClassTests.cs" />
     <Compile Include="AutoMapping\Apm\Conventions\VersionConventionTests.cs" />
+    <Compile Include="AutoMapping\Apm\IdentityTests.cs" />
     <Compile Include="AutoMapping\Overrides\ReferenceComponentOverrides.cs" />
     <Compile Include="AutoMapping\Overrides\AutoMappingOverrideAlterationTests.cs" />
     <Compile Include="AutoMapping\Apm\CacheOverrideTests.cs" />

--- a/src/FluentNHibernate/Automapping/Steps/IdentityStep.cs
+++ b/src/FluentNHibernate/Automapping/Steps/IdentityStep.cs
@@ -1,8 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
 using FluentNHibernate.Mapping;
 using FluentNHibernate.MappingModel;
 using FluentNHibernate.MappingModel.ClassBased;
-using FluentNHibernate.MappingModel.Collections;
 using FluentNHibernate.MappingModel.Identity;
 
 namespace FluentNHibernate.Automapping.Steps
@@ -10,6 +10,7 @@ namespace FluentNHibernate.Automapping.Steps
     public class IdentityStep : IAutomappingStep
     {
         private readonly IAutomappingConfiguration cfg;
+        readonly List<Type> identityCompatibleTypes = new List<Type> { typeof(long), typeof(int), typeof(short), typeof(byte) };
 
         public IdentityStep(IAutomappingConfiguration cfg)
         {
@@ -54,14 +55,14 @@ namespace FluentNHibernate.Automapping.Steps
                 mapping.Set(x => x.Access, Layer.Defaults, cfg.GetAccessStrategyForReadOnlyProperty(member).ToString());
         }
         
-        static GeneratorMapping GetDefaultGenerator(Member property)
+        GeneratorMapping GetDefaultGenerator(Member property)
         {
             var generatorMapping = new GeneratorMapping();
             var defaultGenerator = new GeneratorBuilder(generatorMapping, property.PropertyType, Layer.Defaults);
 
             if (property.PropertyType == typeof(Guid))
                 defaultGenerator.GuidComb();
-            else if (property.PropertyType == typeof(int) || property.PropertyType == typeof(long))
+            else if (identityCompatibleTypes.Contains(property.PropertyType))
                 defaultGenerator.Identity();
             else
                 defaultGenerator.Assigned();


### PR DESCRIPTION
Issue #190 - support for short and byte properties as identity. Courtesy of @laheinzen
