### PR TITLE
Mono-compatability bug fix

### DIFF
--- a/src/FluentNHibernate/MappingModel/Collections/LayeredColumns.cs
+++ b/src/FluentNHibernate/MappingModel/Collections/LayeredColumns.cs
@@ -21,6 +21,9 @@ namespace FluentNHibernate.MappingModel.Collections
 
                 foreach (var value in values)
                 {
+					if (value == null)
+						yield break;
+
                     yield return value;
                 }
             }


### PR DESCRIPTION
Mono-compatability bug fix -- HashSet enumeration returned null for
unknown reason.

This fix was tested on an OSX commercial application using 30+ fluent
mappings. It works now.
