### PR TITLE
Removes unnecessary expression in favour of a compiled lambda.

### DIFF
--- a/src/FluentNHibernate/Conventions/AcceptanceCriteria/ConcreteAcceptanceCriteria.cs
+++ b/src/FluentNHibernate/Conventions/AcceptanceCriteria/ConcreteAcceptanceCriteria.cs
@@ -52,7 +52,7 @@ namespace FluentNHibernate.Conventions.AcceptanceCriteria
             return this;
         }
 
-        public IAcceptanceCriteria<TInspector> Expect(Expression<Func<TInspector, bool>> evaluation)
+        public IAcceptanceCriteria<TInspector> Expect(Func<TInspector, bool> evaluation)
         {
             var expectation = CreateEvalExpectation(evaluation);
 
@@ -113,7 +113,7 @@ namespace FluentNHibernate.Conventions.AcceptanceCriteria
             return new Expectation<TInspector>(expression, value);
         }
 
-        protected virtual IExpectation CreateEvalExpectation(Expression<Func<TInspector, bool>> expression)
+        protected virtual IExpectation CreateEvalExpectation(Func<TInspector, bool> expression)
         {
             return new EvalExpectation<TInspector>(expression);
         }

--- a/src/FluentNHibernate/Conventions/AcceptanceCriteria/EvalExpectation.cs
+++ b/src/FluentNHibernate/Conventions/AcceptanceCriteria/EvalExpectation.cs
@@ -7,18 +7,16 @@ namespace FluentNHibernate.Conventions.AcceptanceCriteria
     public class EvalExpectation<TInspector> : IExpectation
         where TInspector : IInspector
     {
-        private readonly Expression<Func<TInspector, bool>> expression;
+        private readonly Func<TInspector, bool> expression;
 
-        public EvalExpectation(Expression<Func<TInspector, bool>> expression)
+        public EvalExpectation(Func<TInspector, bool> expression)
         {
             this.expression = expression;
         }
 
         public bool Matches(TInspector inspector)
         {
-            var compiledFunc = expression.Compile();
-
-            return compiledFunc(inspector);
+            return expression(inspector);
         }
 
         bool IExpectation.Matches(IInspector inspector)

--- a/src/FluentNHibernate/Conventions/AcceptanceCriteria/IAcceptanceCriteria.cs
+++ b/src/FluentNHibernate/Conventions/AcceptanceCriteria/IAcceptanceCriteria.cs
@@ -13,7 +13,7 @@ namespace FluentNHibernate.Conventions.AcceptanceCriteria
         IAcceptanceCriteria<TInspector> OppositeOf<T>()
             where T : IConventionAcceptance<TInspector>, new();
 
-        IAcceptanceCriteria<TInspector> Expect(Expression<Func<TInspector, bool>> evaluation);
+        IAcceptanceCriteria<TInspector> Expect(Func<TInspector, bool> evaluation);
         IAcceptanceCriteria<TInspector> Expect(Expression<Func<TInspector, object>> propertyExpression, IAcceptanceCriterion value);
 
         // special case for string, because it's actually an IEnumerable<char>, which makes it fall through

--- a/src/FluentNHibernate/Conventions/AcceptanceCriteria/InverterAcceptanceCriteria.cs
+++ b/src/FluentNHibernate/Conventions/AcceptanceCriteria/InverterAcceptanceCriteria.cs
@@ -15,7 +15,7 @@ namespace FluentNHibernate.Conventions.AcceptanceCriteria
             return new InvertedExpectation(expectation);
         }
 
-        protected override IExpectation CreateEvalExpectation(Expression<Func<TInspector, bool>> expression)
+        protected override IExpectation CreateEvalExpectation(Func<TInspector, bool> expression)
         {
             var expectation = base.CreateEvalExpectation(expression);
 


### PR DESCRIPTION
Increases initial configuration speed considerably when using significant
numbers of conventions. refs #226

There are other expression compilations which can be eliminated, but only at the expense of bloating the code and/or breaking changes to the API. The performance gains were negligible in my use case so I have left them alone for now.
