### PR TITLE
ExpressionToSql: Allow using an inherited property when using a lambda

### DIFF
--- a/src/FluentNHibernate.Testing/FluentInterfaceTests/WhereTests.cs
+++ b/src/FluentNHibernate.Testing/FluentInterfaceTests/WhereTests.cs
@@ -103,6 +103,12 @@ namespace FluentNHibernate.Testing.FluentInterfaceTests
                 .ShouldEqual("some where clause");
         }
 
+        [Test]
+        public void ShouldAllowInheritedProperty()
+        {
+            WhereSubChild(x => x.String == SomeValue)
+                .ShouldEqual("String = 'SomeValue'");
+        }
         #region helpers
 
         private string Where(Expression<Func<Child, bool>> where)
@@ -110,6 +116,24 @@ namespace FluentNHibernate.Testing.FluentInterfaceTests
             var classMap = new ClassMap<Target>();
             classMap.Id(x => x.Id);
             classMap.HasMany(x => x.Children)
+                .Where(where);
+
+            var model = new PersistenceModel();
+
+            model.Add(classMap);
+
+            return model.BuildMappings()
+                .First()
+                .Classes.First()
+                .Collections.First()
+                .Where;
+        }
+
+        private string WhereSubChild(Expression<Func<SubChild, bool>> where)
+        {
+            var classMap = new ClassMap<Target>();
+            classMap.Id(x => x.Id);
+            classMap.HasMany(x => x.SubChildren)
                 .Where(where);
 
             var model = new PersistenceModel();
@@ -147,6 +171,7 @@ namespace FluentNHibernate.Testing.FluentInterfaceTests
         {
             public int Id { get; set; }
             public IList<Child> Children { get; set;}
+            public IList<SubChild> SubChildren { get; set; }
         }
 
         private class Child
@@ -154,6 +179,10 @@ namespace FluentNHibernate.Testing.FluentInterfaceTests
             public string String { get; set; }
             public int Int { get; set; }
             public Enum Enum { get; set; }
+        }
+
+        private class SubChild : Child
+        {
         }
 
         private enum Enum

--- a/src/FluentNHibernate/Utils/ExpressionToSql.cs
+++ b/src/FluentNHibernate/Utils/ExpressionToSql.cs
@@ -47,7 +47,7 @@ namespace FluentNHibernate.Utils
             // TODO: should really do something about conventions and overridden names here
             var member = body.Member;
 
-            if (member.DeclaringType == typeof(T))
+            if (member.DeclaringType.IsAssignableFrom(typeof(T)))
                 return member.Name;
                 
             // try get value of lambda, hoping it's just a direct value return or local reference


### PR DESCRIPTION
Hi, this is my first contribution so if I'm doing anything wrong please let me know.
I has an issue where I had a OneToMany mapping of a subType and I couldn't use a lambda to specify a condition on an inherited property. Since the fix was so simple I decided to fix it and send it in.
