### PR TITLE
Made Fluently instantiable

### DIFF
--- a/src/FluentNHibernate/Cfg/Fluently.cs
+++ b/src/FluentNHibernate/Cfg/Fluently.cs
@@ -5,8 +5,17 @@ namespace FluentNHibernate.Cfg
     /// <summary>
     /// Fluently configure NHibernate
     /// </summary>
-    public static class Fluently
+    public class Fluently
     {
+        /// <summary>
+        /// Begin fluently configuring NHibernate
+        /// </summary>
+        /// <returns>Fluent Configuration</returns>
+        public FluentConfiguration BeginConfigure()
+        {
+            return Fluently.Configure();
+        }
+        
         /// <summary>
         /// Begin fluently configuring NHibernate
         /// </summary>
@@ -14,6 +23,16 @@ namespace FluentNHibernate.Cfg
         public static FluentConfiguration Configure()
         {
             return new FluentConfiguration();
+        }
+        
+        /// <summary>
+        /// Begin fluently configuring NHibernate
+        /// </summary>
+        /// <param name="cfg">Instance of an NHibernate Configuration</param>
+        /// <returns>Fluent Configuration</returns>
+        public FluentConfiguration BeginConfigure(Configuration cfg)
+        {
+            return Fluently.Configure(cfg);
         }
 
         /// <summary>


### PR DESCRIPTION
Fluenty can not be injected via IoC-Containers, making it hard to test classes, that use it.
