### PR TITLE
Fixed typo on PropertyPart.Unique documentation

### DIFF
--- a/src/FluentNHibernate/Mapping/PropertyPart.cs
+++ b/src/FluentNHibernate/Mapping/PropertyPart.cs
@@ -234,7 +234,7 @@ namespace FluentNHibernate.Mapping
         }
 
         /// <summary>
-        /// Specify that this property has a unique constranit
+        /// Specify that this property has a unique constraint
         /// </summary>
         public PropertyPart Unique()
         {


### PR DESCRIPTION
I've fixed a small typo on PropertyPart.Unique documentation, which was "constranit" instead of "constraint".
