### PR TITLE
EnsureMappingsBuild is called in PersistenceModel.ImportProviders to pre...

### DIFF
--- a/src/FluentNHibernate.Testing/Cfg/DuplicateMappingTests.cs
+++ b/src/FluentNHibernate.Testing/Cfg/DuplicateMappingTests.cs
@@ -1,0 +1,80 @@
+using FluentNHibernate.Automapping;
+using FluentNHibernate.Cfg;
+using FluentNHibernate.Cfg.Db;
+using FluentNHibernate.Mapping;
+using NHibernate.Cfg;
+using NHibernate.Mapping;
+using NUnit.Framework;
+
+namespace FluentNHibernate.Testing.Cfg
+{
+    [TestFixture]
+    public class DuplicateMappingTests
+    {
+        private Configuration cfg;
+        private MappingConfiguration mapping;
+
+        [SetUp]
+        public void CreateMappingConfiguration()
+        {
+            cfg = new Configuration();
+
+            SQLiteConfiguration.Standard
+                .InMemory()
+                .ConfigureProperties(cfg);
+
+            mapping = new MappingConfiguration();
+        }
+
+        [Test]
+        public void FluentMappingOfInheritedAutomappedTypeShouldBeIgnoredForSubclasses()
+        {
+            mapping.FluentMappings.Add(typeof(TypeInfoMap));
+            mapping.FluentMappings.Add(typeof(MessageTypeMap));
+            mapping.AutoMappings.Add(AutoMap.Source(new StubTypeSource(typeof(ActiveRecord))));
+            mapping.Apply(cfg);
+
+            var arMapping = cfg.GetClassMapping(typeof(ActiveRecord));
+            arMapping.SubclassIterator.GetEnumerator().MoveNext().ShouldBeFalse();
+            var messageTypeMapping = cfg.GetClassMapping(typeof(MessageType)) as SingleTableSubclass;
+            messageTypeMapping.IsJoinedSubclass.ShouldBeFalse();
+        }
+
+        #region TestModel
+
+        public class ActiveRecord
+        {
+            public virtual int Id { get; set; }
+        }
+
+        public class TypeInfo : ActiveRecord
+        {
+            public virtual int ClassId { get; set; }
+        }
+
+        public class MessageType : TypeInfo
+        {
+        }
+
+        public class TypeInfoMap : ClassMap<TypeInfo>
+        {
+            public TypeInfoMap()
+            {
+                Table("TypeInfoNH");
+                Id(t => t.Id).GeneratedBy.HiLo("10");
+                Map(t => t.ClassId).ReadOnly();
+                DiscriminateSubClassesOnColumn("ClassId", 102);
+            }
+        }
+
+        public class MessageTypeMap : SubclassMap<MessageType>
+        {
+            public MessageTypeMap()
+            {
+                DiscriminatorValue(305);
+            }
+        }
+
+        #endregion
+    }
+}

--- a/src/FluentNHibernate.Testing/FluentNHibernate.Testing.csproj
+++ b/src/FluentNHibernate.Testing/FluentNHibernate.Testing.csproj
@@ -126,6 +126,7 @@
     <Compile Include="AutoMapping\Overrides\CompositeIdOverrides.cs" />
     <Compile Include="AutoMapping\Overrides\HibernateMappingOverrides.cs" />
     <Compile Include="Cfg\Db\SqlAnywhereConfigurationTester.cs" />
+    <Compile Include="Cfg\DuplicateMappingTests.cs" />
     <Compile Include="DomainModel\Mapping\ManyToManySelfReferencedInverseIntegrationTester.cs" />
     <Compile Include="DomainModel\Mapping\MultipleKeyColumnsTester.cs" />
     <Compile Include="DomainModel\MemberAccessResolverTests.cs" />
@@ -416,10 +417,8 @@
     <Compile Include="Testing\Values\ReferencePropertySpecs.cs" />
     <Compile Include="Testing\Values\PropertySpecs.cs" />
     <Compile Include="Testing\Values\Entities.cs" />
-
     <Compile Include="Utils\ReflectionHelperTests.cs" />
     <Compile Include="Testing\XmlWriterTestHelper.cs" />
-
     <Compile Include="Utils\TypeReferenceEqualityTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Visitors\ComponentColumnPrefixVisitorSpecs.cs" />

--- a/src/FluentNHibernate/PersistenceModel.cs
+++ b/src/FluentNHibernate/PersistenceModel.cs
@@ -312,6 +312,8 @@ namespace FluentNHibernate
 
         internal void ImportProviders(PersistenceModel model)
         {
+            EnsureMappingsBuilt();
+
             model.classProviders.Each(x =>
             {
                 if (!classProviders.Contains(x))


### PR DESCRIPTION
I have to map a legacy database with the following (simplified) structure

ActiveRecord        Root Table and Class
TypeInfo            Child Table and Class with foreign key to ActiveRecord
MessageType     Class that is also mapped to the TypeInfo table

As it is not possible to mix table per subclass and table per hierarchy in one inheritance tree, 
I mapped TypeInfo to a view and made it a new root table. To accomplish this, a FluentMapping was used
in addition to the other automapped tables.
With the current FNH version this causes a DuplicateMapping exception as MessageType is also mapped as joined subclass of the ActiveRecord class.
I fixed that, calling EnsureMappingsBuild in PersistenceModel.ImportProviders.
I'm not sure if this is the exactly correct place - nevertheless all existing UTs succeed.
