### PR TITLE
Fix for bug #231

### DIFF
--- a/src/FluentNHibernate.Testing/MappingModel/Output/XmlKeyPropertyWriterTester.cs
+++ b/src/FluentNHibernate.Testing/MappingModel/Output/XmlKeyPropertyWriterTester.cs
@@ -64,5 +64,14 @@ namespace FluentNHibernate.Testing.MappingModel.Output
 
             testHelper.VerifyAll(writer);
         }
+
+        [Test(Description = "Bug #231 :: Bug when trying to change varchar length for CompositeId")]
+        public void WhenKeyPropertyMappingContainsLengthAndCustomColumnLengthAttributeIsRenderedIntoColumnElement()
+        {
+            var keyPropertyMapping = new KeyPropertyMapping();
+            keyPropertyMapping.Set(propertyMapping => propertyMapping.Length, Layer.Defaults, 2);
+            keyPropertyMapping.AddColumn(new ColumnMapping());
+            writer.VerifyXml(keyPropertyMapping).DoesntHaveAttribute("length").Element("column").HasAttribute("length", "2");
+        }
     }
 }

--- a/src/FluentNHibernate/MappingModel/Output/XmlKeyPropertyWriter.cs
+++ b/src/FluentNHibernate/MappingModel/Output/XmlKeyPropertyWriter.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Xml;
 using FluentNHibernate.MappingModel.Identity;
 using FluentNHibernate.Utils;
@@ -39,7 +40,19 @@ namespace FluentNHibernate.MappingModel.Output
                 element.WithAtt("type", mapping.Type);
 
             if (mapping.IsSpecified("Length"))
-                element.WithAtt("length", mapping.Length);
+            {
+                if (mapping.Columns.Any())
+                {
+                    foreach (var columnMapping in mapping.Columns.Where(column => !column.IsSpecified("Length")))
+                    {
+                        columnMapping.Set(map => map.Length, Layer.Defaults, mapping.Length);
+                    }   
+                }
+                else
+                {
+                    element.WithAtt("length", mapping.Length);
+                }
+            }
         }
 
         public override void Visit(ColumnMapping columnMapping)


### PR DESCRIPTION
After reading this bug, I tried to solve it with the next statement: If Key Property contains Length and exist a column added to the Key Property without length attribute setted, during Xml rendering it overrides the attribute on Column instead on Key Property (If NHibernate actually ignores length on key property when column exist, it doesn't have any value). It's a good solution? Thanks
