### PR TITLE
Lock Nuget NHibernate versions to < 4.0.

### DIFF
--- a/RakeFile
+++ b/RakeFile
@@ -170,7 +170,7 @@ namespace :package do
     nu.language = 'en-US'
     nu.licenseUrl = 'http://github.com/jagregory/fluent-nhibernate/raw/master/LICENSE.txt'
     nu.projectUrl = 'http://fluentnhibernate.org'
-    nu.dependency 'NHibernate', '3.3.1.4000'
+    nu.dependency 'NHibernate', '[3.3.1.4000,4)'
     nu.working_directory = 'build'
     nu.output_file = 'fluentnhibernate.nuspec'
     nu.file 'FluentNHibernate.dll', 'lib'

--- a/src/Examples.FirstAutomappedProject/packages.config
+++ b/src/Examples.FirstAutomappedProject/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Iesi.Collections" version="3.2.0.4000" targetFramework="net35" />
-  <package id="NHibernate" version="3.3.3.4001" targetFramework="net35" />
+  <package id="Iesi.Collections" version="3.2.0.4000" targetFramework="net35" allowedVersions="[3,4)"/>
+  <package id="NHibernate" version="3.3.3.4001" targetFramework="net35" allowedVersions="[3,4)"/>
   <package id="System.Data.SQLite" version="1.0.66.1" targetFramework="net35" />
 </packages>

--- a/src/Examples.FirstProject/packages.config
+++ b/src/Examples.FirstProject/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Iesi.Collections" version="3.2.0.4000" targetFramework="net35" />
-  <package id="NHibernate" version="3.3.3.4001" targetFramework="net35" />
+  <package id="Iesi.Collections" version="3.2.0.4000" targetFramework="net35" allowedVersions="[3,4)"/>
+  <package id="NHibernate" version="3.3.3.4001" targetFramework="net35" allowedVersions="[3,4)"/>
   <package id="System.Data.SQLite" version="1.0.66.1" targetFramework="net35" />
 </packages>

--- a/src/FluentNHibernate.Specs.ExternalFixtures/packages.config
+++ b/src/FluentNHibernate.Specs.ExternalFixtures/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Iesi.Collections" version="3.2.0.4000" targetFramework="net35" />
-  <package id="NHibernate" version="3.3.3.4001" targetFramework="net35" />
+  <package id="Iesi.Collections" version="3.2.0.4000" targetFramework="net35" allowedVersions="[3,4)"/>
+  <package id="NHibernate" version="3.3.3.4001" targetFramework="net35" allowedVersions="[3,4)"/>
 </packages>

--- a/src/FluentNHibernate.Specs/packages.config
+++ b/src/FluentNHibernate.Specs/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Iesi.Collections" version="3.2.0.4000" targetFramework="net35" />
+  <package id="Iesi.Collections" version="3.2.0.4000" targetFramework="net35" allowedVersions="[3,4)"/>
   <package id="Machine.Specifications" version="0.5.15" targetFramework="net35" />
-  <package id="NHibernate" version="3.3.3.4001" targetFramework="net35" />
+  <package id="NHibernate" version="3.3.3.4001" targetFramework="net35" allowedVersions="[3,4)"/>
 </packages>

--- a/src/FluentNHibernate.Testing/packages.config
+++ b/src/FluentNHibernate.Testing/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="FakeItEasy" version="1.15.0" targetFramework="net35" />
-  <package id="Iesi.Collections" version="3.2.0.4000" targetFramework="net35" />
+  <package id="Iesi.Collections" version="3.2.0.4000" targetFramework="net35" allowedVersions="[3,4)"/>
   <package id="Machine.Specifications" version="0.5.15" targetFramework="net35" />
-  <package id="NHibernate" version="3.3.3.4001" targetFramework="net35" />
+  <package id="NHibernate" version="3.3.3.4001" targetFramework="net35" allowedVersions="[3,4)"/>
   <package id="NUnit" version="2.5.7.10213" targetFramework="net35" />
   <package id="System.Data.SQLite" version="1.0.66.1" targetFramework="net35" />
 </packages>

--- a/src/FluentNHibernate.nuspec
+++ b/src/FluentNHibernate.nuspec
@@ -8,11 +8,11 @@
     <licenseUrl>http://github.com/jagregory/fluent-nhibernate/blob/master/LICENSE.txt</licenseUrl>
     <projectUrl>http://github.com/jagregory/fluent-nhibernate/</projectUrl>
 	<dependencies>
-		<dependency id="NHibernate" version="[3.3.1.4000,)" />
+		<dependency id="NHibernate" version="[3.3.1.4000,4)" />
 	</dependencies>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Fluent, XML-less, compile safe, automated, convention-based mappings for NHibernate.</description>
-    <summary>Fluent NHibernate provides a conventient way to configure NHibernate - no XML involved.</summary>
+    <summary>Fluent NHibernate provides a convenient way to configure NHibernate - no XML involved.</summary>
 	<tags>orm dal nhibernate conventions</tags>
     <language>en-US</language>
   </metadata>

--- a/src/FluentNHibernate/packages.config
+++ b/src/FluentNHibernate/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Iesi.Collections" version="3.2.0.4000" targetFramework="net35" />
-  <package id="NHibernate" version="3.3.3.4001" targetFramework="net35" />
+  <package id="Iesi.Collections" version="3.2.0.4000" targetFramework="net35" allowedVersions="[3,4)"/>
+  <package id="NHibernate" version="3.3.3.4001" targetFramework="net35" allowedVersions="[3,4)"/>
 </packages>


### PR DESCRIPTION
The current FluentNHibernate version on Nuget depens on NH >= 3.3.1.4000. I believe it would be helpful to tighten this dependency to >= 3.3.1.4000 and < 4.0, in preparation for NH 4.0 release.

The NH 4.0 release could happen any day now.
