### PR TITLE
Quick fix for #123: Append cascade options instead of overwriting.

### DIFF
--- a/src/FluentNHibernate.Testing/FluentInterfaceTests/ManyToOneMutablePropertyModelGenerationTests.cs
+++ b/src/FluentNHibernate.Testing/FluentInterfaceTests/ManyToOneMutablePropertyModelGenerationTests.cs
@@ -26,6 +26,14 @@ namespace FluentNHibernate.Testing.FluentInterfaceTests
         }
 
         [Test]
+        public void CascadeShouldAppendModelCascadePropertyToValue()
+        {
+            ManyToOne()
+                .Mapping(m => { m.Cascade.SaveUpdate(); m.Cascade.Merge(); })
+                .ModelShouldMatch(x => x.Cascade.ShouldEqual("save-update,merge"));
+        }
+
+        [Test]
         public void ShouldSetModelClassPropertyToPropertyType()
         {
             ManyToOne()

--- a/src/FluentNHibernate.Testing/FluentInterfaceTests/OneToManyMutablePropertyModelGenerationTests.cs
+++ b/src/FluentNHibernate.Testing/FluentInterfaceTests/OneToManyMutablePropertyModelGenerationTests.cs
@@ -46,6 +46,14 @@ namespace FluentNHibernate.Testing.FluentInterfaceTests
         }
 
         [Test]
+        public void CascadeShouldAppendModelCascadePropertyToValue()
+        {
+            OneToMany(x => x.BagOfChildren)
+                .Mapping(m => { m.Cascade.SaveUpdate(); m.Cascade.Merge(); })
+                .ModelShouldMatch(x => x.Cascade.ShouldEqual("save-update,merge"));
+        }
+
+        [Test]
         public void CollectionTypeShouldSetModelCollectionTypePropertyToValue()
         {
             OneToMany(x => x.BagOfChildren)

--- a/src/FluentNHibernate/Mapping/ManyToOnePart.cs
+++ b/src/FluentNHibernate/Mapping/ManyToOnePart.cs
@@ -27,7 +27,11 @@ namespace FluentNHibernate.Mapping
             this.member = member;
             access = new AccessStrategyBuilder<ManyToOnePart<TOther>>(this, value => attributes.Set("Access", Layer.UserSupplied, value));
             fetch = new FetchTypeExpression<ManyToOnePart<TOther>>(this, value => attributes.Set("Fetch", Layer.UserSupplied, value));
-            cascade = new CascadeExpression<ManyToOnePart<TOther>>(this, value => attributes.Set("Cascade", Layer.UserSupplied, value));
+            cascade = new CascadeExpression<ManyToOnePart<TOther>>(this, value =>
+                {
+                    var current = attributes.Get("Cascade") as string;
+                    attributes.Set("Cascade", Layer.UserSupplied, current == null ? value : string.Format("{0},{1}", current, value));
+                });
             notFound = new NotFoundExpression<ManyToOnePart<TOther>>(this, value => attributes.Set("NotFound", Layer.UserSupplied, value));
 
             SetDefaultAccess();

--- a/src/FluentNHibernate/Mapping/OneToManyPart.cs
+++ b/src/FluentNHibernate/Mapping/OneToManyPart.cs
@@ -31,7 +31,11 @@ namespace FluentNHibernate.Mapping
             childType = collectionType;
 
             keyColumns = new ColumnMappingCollection<OneToManyPart<TChild>>(this);
-            cascade = new CollectionCascadeExpression<OneToManyPart<TChild>>(this, value => collectionAttributes.Set("Cascade", Layer.UserSupplied, value));
+            cascade = new CollectionCascadeExpression<OneToManyPart<TChild>>(this, value => 
+                {
+                    var current = collectionAttributes.Get("Cascade") as string;
+                    collectionAttributes.Set("Cascade", Layer.UserSupplied, current == null ? value : string.Format("{0},{1}", current, value));
+                });
             notFound = new NotFoundExpression<OneToManyPart<TChild>>(this, value => relationshipAttributes.Set("NotFound", Layer.UserSupplied, value));
 
             collectionAttributes.Set("Name", Layer.Defaults, member.Name);


### PR DESCRIPTION
It's kind of a blocker in my opinion that I cannot use multiple cascade options at once like in NHibernate.
