### PR TITLE
Automapper: union-subtree not propagating through class hierarchy

### DIFF
--- a/src/FluentNHibernate.Testing/AutoMapping/TestFixtures.cs
+++ b/src/FluentNHibernate.Testing/AutoMapping/TestFixtures.cs
@@ -525,3 +525,26 @@ namespace FluentNHibernate.Automapping.TestFixtures.SuperTypes
         Mixed
     }
 }
+
+namespace FluentNHibernate.Automapping.TestFixtures.UnionChain
+{
+    public class BaseUnionType
+    {
+        public int Id { get; set; }
+    }
+
+    public class ChildUnionType : BaseUnionType
+    {
+        public int Value { get; set; }
+    }
+
+    public class GrandChildUnionType : ChildUnionType
+    {
+        public string Name { get; set; }
+    }
+
+    public class GreatGrandChildUnionType : GrandChildUnionType
+    {
+    }
+}
+

--- a/src/FluentNHibernate.Testing/AutoMapping/UnionSubclassConventionTests.cs
+++ b/src/FluentNHibernate.Testing/AutoMapping/UnionSubclassConventionTests.cs
@@ -1,5 +1,6 @@
 using FluentNHibernate.Automapping;
 using FluentNHibernate.Automapping.TestFixtures.SuperTypes;
+using FluentNHibernate.Automapping.TestFixtures.UnionChain;
 using NUnit.Framework;
 
 namespace FluentNHibernate.Testing.Automapping
@@ -18,5 +19,29 @@ namespace FluentNHibernate.Testing.Automapping
                 .HasAttribute("name", "Parent_id");
             //.Element("class/union-subclass").Exists();
         }
+
+        [Test]
+        public void UnionSubtypePropagatesThroughHierarchy()
+        {
+            new AutoMappingTester<BaseUnionType>(
+                AutoMap.AssemblyOf<BaseUnionType>()
+                    .Where(x => x.Namespace == typeof(BaseUnionType).Namespace)
+                    .Override<BaseUnionType>(m => m.UseUnionSubclassForInheritanceMapping()))
+                .Element("class[@name = '" + typeof(BaseUnionType).AssemblyQualifiedName + "']")
+                .Exists()
+                .Element("class/union-subclass[@name='" + typeof(ChildUnionType).AssemblyQualifiedName + "']")
+                .Exists()
+                .Element("class/union-subclass/joined-subclass")
+                .DoesntExist()
+                .Element("class/union-subclass[@name='" + typeof(ChildUnionType).AssemblyQualifiedName + "']/" +
+                          "union-subclass[@name='" + typeof(GrandChildUnionType).AssemblyQualifiedName + "']")
+                .Exists()
+                .Element("class/union-subclass[@name='" + typeof(ChildUnionType).AssemblyQualifiedName + "']/" +
+                          "union-subclass[@name='" + typeof(GrandChildUnionType).AssemblyQualifiedName + "']/" +
+                          "union-subclass[@name='" + typeof(GreatGrandChildUnionType).AssemblyQualifiedName + "']")
+                .Exists()
+                ;
+        }
+
     }
 }

--- a/src/FluentNHibernate/Automapping/AutoMapper.cs
+++ b/src/FluentNHibernate/Automapping/AutoMapper.cs
@@ -78,8 +78,13 @@ namespace FluentNHibernate.Automapping
                 }
 
                 SubclassMapping subclassMapping;
-
+                var tempSubClassMap = mapping as SubclassMapping;
                 if(!tempIsNull && tempMapping.IsUnionSubclass)
+                {
+                    subclassMapping = new SubclassMapping(SubclassType.UnionSubclass);
+                    subclassMapping.Set(x => x.Type, Layer.Defaults, inheritedClass.Type);
+                }
+                else if (tempSubClassMap != null && tempSubClassMap.SubclassType == SubclassType.UnionSubclass)
                 {
                     subclassMapping = new SubclassMapping(SubclassType.UnionSubclass);
                     subclassMapping.Set(x => x.Type, Layer.Defaults, inheritedClass.Type);


### PR DESCRIPTION
I am converting a project from using ClassMaps to using the AutoMapper in order to simplify the existing project and any future changes.  One class inheritance tree in the project is built using UnionSubclassMapping and when attempting to build the NH configuration using the automapper, the following error is thrown:

> NHibernate.MappingException: (XmlDocument)(267,8): XML validation error: The element 'union-subclass' in namespace 'urn:nhibernate-mapping-2.2' has invalid child element 'joined-subclass' in namespace 'urn:nhibernate-mapping-2.2'. List of possible elements expected: 'property, many-to-one, one-to-one, component, dynamic-component, properties, any, map, set, list, bag, idbag, array, primitive-array, union-subclass, loader, sql-insert, sql-update, sql-delete, results
> et, query, sql-query' in namespace 'urn:nhibernate-mapping-2.2'.

This inheritance tree has three layers. The AutoMapper was not carrying the knowledge that union-subtree was to be used down to the grandchild object, which caused it to switch and start using joined-subtree, which is not allowed.

I have assembled a patch and a test for checking the issue.  I don't know if a similar issue exists for other subclassing strategies.  I can also confirm that the patched version of Fluent works with my project and it is now generating correct HBM files.
