### PR TITLE
Removed invalid cast in ClassInspector.Components.

### DIFF
--- a/src/FluentNHibernate/Conventions/Inspections/ClassInspector.cs
+++ b/src/FluentNHibernate/Conventions/Inspections/ClassInspector.cs
@@ -143,9 +143,9 @@ namespace FluentNHibernate.Conventions.Inspections
                     .Select(x =>
                     {
                         if (x.ComponentType == ComponentType.Component)
-                            return (IComponentBaseInspector)new ComponentInspector((ComponentMapping)x);
+                            return (IComponentBaseInspector)new ComponentInspector(x);
 
-                        return (IComponentBaseInspector)new DynamicComponentInspector((ComponentMapping)x);
+                        return (IComponentBaseInspector)new DynamicComponentInspector(x);
                     });
             }
         }

--- a/src/FluentNHibernate/Conventions/Inspections/ISubclassInspectorBase.cs
+++ b/src/FluentNHibernate/Conventions/Inspections/ISubclassInspectorBase.cs
@@ -9,6 +9,7 @@ namespace FluentNHibernate.Conventions.Inspections
         bool Abstract { get; }
         IEnumerable<IAnyInspector> Anys { get; }
         IEnumerable<ICollectionInspector> Collections { get; }
+        IEnumerable<IComponentBaseInspector> Components { get; }
         IEnumerable<IJoinInspector> Joins { get; }
         IEnumerable<IOneToOneInspector> OneToOnes { get; }
         IEnumerable<IPropertyInspector> Properties { get; }

--- a/src/FluentNHibernate/Conventions/Inspections/JoinedSubclassInspector.cs
+++ b/src/FluentNHibernate/Conventions/Inspections/JoinedSubclassInspector.cs
@@ -74,6 +74,21 @@ namespace FluentNHibernate.Conventions.Inspections
             }
         }
 
+        public IEnumerable<IComponentBaseInspector> Components
+        {
+            get
+            {
+                return mapping.Components
+                    .Select(x =>
+                    {
+                        if (x.ComponentType == ComponentType.Component)
+                            return (IComponentBaseInspector)new ComponentInspector(x);
+
+                        return (IComponentBaseInspector)new DynamicComponentInspector(x);
+                    });
+            }
+        }
+
         public bool DynamicInsert
         {
             get { return mapping.DynamicInsert; }

--- a/src/FluentNHibernate/Conventions/Inspections/SubclassInspector.cs
+++ b/src/FluentNHibernate/Conventions/Inspections/SubclassInspector.cs
@@ -58,6 +58,21 @@ namespace FluentNHibernate.Conventions.Inspections
             }
         }
 
+        public IEnumerable<IComponentBaseInspector> Components
+        {
+            get
+            {
+                return mapping.Components
+                    .Select(x =>
+                    {
+                        if (x.ComponentType == ComponentType.Component)
+                            return (IComponentBaseInspector)new ComponentInspector(x);
+
+                        return (IComponentBaseInspector)new DynamicComponentInspector(x);
+                    });
+            }
+        }
+
         public object DiscriminatorValue
         {
             get { return mapping.DiscriminatorValue; }


### PR DESCRIPTION
Similar issue to PR #324: ClassInspector.Components had some leftover casts that are no longer valid.
