### PR TITLE
Automapper overrides joins for sub classes

### DIFF
--- a/src/FluentNHibernate.Specs/Automapping/OverrideSpecs.cs
+++ b/src/FluentNHibernate.Specs/Automapping/OverrideSpecs.cs
@@ -1,9 +1,6 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Linq;
 using FluentNHibernate.Automapping;
 using FluentNHibernate.Automapping.Alterations;
-using FluentNHibernate.MappingModel;
 using FluentNHibernate.MappingModel.ClassBased;
 using FluentNHibernate.Specs.Automapping.Fixtures;
 using FluentNHibernate.Specs.Automapping.Fixtures.Overrides;

--- a/src/FluentNHibernate.Specs/Automapping/OverrideSpecs.cs
+++ b/src/FluentNHibernate.Specs/Automapping/OverrideSpecs.cs
@@ -1,6 +1,9 @@
-﻿using System.Linq;
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 using FluentNHibernate.Automapping;
 using FluentNHibernate.Automapping.Alterations;
+using FluentNHibernate.MappingModel;
 using FluentNHibernate.MappingModel.ClassBased;
 using FluentNHibernate.Specs.Automapping.Fixtures;
 using FluentNHibernate.Specs.Automapping.Fixtures.Overrides;
@@ -29,6 +32,33 @@ namespace FluentNHibernate.Specs.Automapping
         It should_exclude_the_join_mapped_property_from_the_main_automapping = () =>
             mapping.Properties.Select(x => x.Name).ShouldNotContain("One");
         
+        static AutoPersistenceModel model;
+        static ClassMapping mapping;
+    }
+
+
+    public class when_using_an_automapping_override_to_specify_a_discriminators_and_join_on_subclass
+    {
+        private Establish context = () =>
+            model = AutoMap.Source(new StubTypeSource(typeof (Parent), typeof (Child)))
+                .Override<Parent>(map =>
+                    map.DiscriminateSubClassesOnColumn("type"))
+                .Override<Child>(map => map.Join("table", part => { }));
+
+        private Because of = () => 
+            mapping = model.BuildMappingFor<Parent>();
+           
+
+
+        It should_not_create_the_join_mapping = () =>
+            mapping.Joins.ShouldBeEmpty();
+
+        It should_map_the_discriminator = () =>
+            mapping.Discriminator.ShouldNotBeNull();
+
+        It should_map_subclasses_as_joined_subclasses = () =>
+            mapping.Subclasses.ShouldEachConformTo(x => x.Joins.Any());
+
         static AutoPersistenceModel model;
         static ClassMapping mapping;
     }

--- a/src/FluentNHibernate/Automapping/AutoMapping.cs
+++ b/src/FluentNHibernate/Automapping/AutoMapping.cs
@@ -61,21 +61,11 @@ namespace FluentNHibernate.Automapping
                 if (Cache.IsDirty)
                     classMapping.Set(x => x.Cache, Layer.Defaults, ((ICacheMappingProvider)Cache).GetCacheMapping());
 
-                foreach (var join in providers.Joins)
-                    classMapping.AddJoin(join.GetJoinMapping());
-
                 classMapping.Set(x => x.Tuplizer, Layer.Defaults, providers.TuplizerMapping);
             }
 
             foreach (var join in providers.Joins)
-            {
-                var joinMapping = join.GetJoinMapping();
-
-                if(mapping.Joins.All(x => x.TableName != joinMapping.TableName))
-                {
-                    mapping.AddJoin(joinMapping);
-                }
-            }
+                mapping.AddOrReplaceJoin(join.GetJoinMapping());
 
             foreach (var property in providers.Properties)
                 mapping.AddOrReplaceProperty(property.GetPropertyMapping());

--- a/src/FluentNHibernate/Automapping/AutoMapping.cs
+++ b/src/FluentNHibernate/Automapping/AutoMapping.cs
@@ -67,6 +67,16 @@ namespace FluentNHibernate.Automapping
                 classMapping.Set(x => x.Tuplizer, Layer.Defaults, providers.TuplizerMapping);
             }
 
+            foreach (var join in providers.Joins)
+            {
+                var joinMapping = join.GetJoinMapping();
+
+                if(mapping.Joins.All(x => x.TableName != joinMapping.TableName))
+                {
+                    mapping.AddJoin(joinMapping);
+                }
+            }
+
             foreach (var property in providers.Properties)
                 mapping.AddOrReplaceProperty(property.GetPropertyMapping());
 

--- a/src/FluentNHibernate/MappingModel/ClassBased/ClassMappingBase.cs
+++ b/src/FluentNHibernate/MappingModel/ClassBased/ClassMappingBase.cs
@@ -146,6 +146,11 @@ namespace FluentNHibernate.MappingModel.ClassBased
             mappedMembers.AddJoin(mapping);
         }
 
+        public void AddOrReplaceJoin(JoinMapping mapping)
+        {
+            mappedMembers.AddOrReplaceJoin(mapping);
+        }
+
         public void AddFilter(FilterMapping mapping)
         {
             mappedMembers.AddFilter(mapping);

--- a/src/FluentNHibernate/MappingModel/MappedMembers.cs
+++ b/src/FluentNHibernate/MappingModel/MappedMembers.cs
@@ -177,6 +177,12 @@ namespace FluentNHibernate.MappingModel
             joins.Add(mapping);
         }
 
+        public void AddOrReplaceJoin(JoinMapping mapping)
+        {
+            joins.RemoveAll(x => x.TableName == mapping.TableName);
+            joins.Add(mapping);
+        }
+
         public void AddFilter(FilterMapping mapping)
         {
             if (filters.Exists(x => x.Name == mapping.Name))


### PR DESCRIPTION
Currently Fluent NHibernate ignores Automapping overrides for subclasses that uses in a class hierarchy with discriminator column.

Thus, it's impossible to produce an hibernate mapping that mixes Table-per-subclass and Table-per-hierarchy like:

```xml
<class name="Payment" table="PAYMENT">
    <id name="Id" type="Int64" column="PAYMENT_ID">
        <generator class="native"/>
    </id>
    <discriminator column="PAYMENT_TYPE" type="string"/>
    <property name="Amount" column="AMOUNT"/>
    ...
    <subclass name="CreditCardPayment" discriminator-value="CREDIT">
        <join table="CREDIT_PAYMENT">
            <property name="CreditCardType" column="CCTYPE"/>
            ...
        </join>
    </subclass>
    <subclass name="CashPayment" discriminator-value="CASH">
        ...
    </subclass>
    <subclass name="ChequePayment" discriminator-value="CHEQUE">
        ...
    </subclass>
</class>
```

My commit fixes this problem: Join override can now be used both for class and subclass automapper overrides. 
