### PR TITLE
Updated NHibernate to 5.2.4.

### DIFF
--- a/nuspec/FluentNHibernate.nuspec
+++ b/nuspec/FluentNHibernate.nuspec
@@ -16,13 +16,13 @@
     <copyright>Copyright (c) James Gregory and contributors (Paul Batum, Hudson Akridge, Gleb Chermennov, Jorge Rodríguez Galán).</copyright>
     <dependencies>
       <group targetFramework="net461" >
-        <dependency id="NHibernate" version="5.1.1" />
+        <dependency id="NHibernate" version="5.2.4" />
       </group>
       <group targetFramework="netstandard2.0">
-        <dependency id="NHibernate" version="5.1.1" />
+        <dependency id="NHibernate" version="5.2.4" />
       </group>
       <group targetFramework="netcoreapp2.0">
-        <dependency id="NHibernate" version="5.1.1" />
+        <dependency id="NHibernate" version="5.2.4" />
       </group>
     </dependencies>
   </metadata>

--- a/nuspec/FluentNHibernate.symbols.nuspec
+++ b/nuspec/FluentNHibernate.symbols.nuspec
@@ -15,7 +15,7 @@
     <tags>ORM DAL NHibernate DataBase ADO.Net Mappings Conventions</tags>
     <copyright>Copyright (c) James Gregory and contributors (Paul Batum, Hudson Akridge, Gleb Chermennov, Jorge Rodríguez Galán).</copyright>
     <dependencies>
-  		<dependency id="NHibernate" version="5.1.1" />
+  		<dependency id="NHibernate" version="5.2.4" />
   	</dependencies>
   </metadata>
   <files>

--- a/src/FluentNHibernate/Cfg/Db/SybaseSQLAnywhereConnectionStringBuilder.cs
+++ b/src/FluentNHibernate/Cfg/Db/SybaseSQLAnywhereConnectionStringBuilder.cs
@@ -1,4 +1,3 @@
-using System.Data.SqlClient;
 using System.Text;
 
 namespace FluentNHibernate.Cfg.Db

--- a/src/Shared.msbuild
+++ b/src/Shared.msbuild
@@ -41,7 +41,7 @@
   </PropertyGroup>
   
   <PropertyGroup Label="Package Versions">
-    <NHibernatePackageVersion>5.1.1</NHibernatePackageVersion>
+    <NHibernatePackageVersion>5.2.4</NHibernatePackageVersion>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
In our legacy codebase, we load several assemblies via reflection. Due to this, assembly redirects won't generate automatically for those assemblies. In these assemblies, FluentNHibernate is referenced. This leads to a assembly conflict, because we reference the latest NHibernate 5.2.4 directly in our other projects.
