### PR TITLE
Use Any extension method in EnumerableExtensionsForConventions.IsEmpty and IsNotEmpty

### DIFF
--- a/src/FluentNHibernate/Conventions/EnumerableExtensionsForConventions.cs
+++ b/src/FluentNHibernate/Conventions/EnumerableExtensionsForConventions.cs
@@ -37,12 +37,12 @@ namespace FluentNHibernate.Conventions
 
         public static bool IsEmpty<T>(this IEnumerable<T> collection)
         {
-            return collection.Count() == 0;
+            return !collection.Any();
         }
 
         public static bool IsNotEmpty<T>(this IEnumerable<T> collection)
         {
-            return !IsEmpty(collection);
+            return collection.Any();
         }
     }
 }


### PR DESCRIPTION
Updated methods to use the Any() Linq extension method. Using Count() is horrible for performance.