### PR TITLE
Add KeyColumn override to AutoMapping<>

### DIFF
--- a/src/FluentNHibernate.Testing/AutoMapping/Apm/AutoPersistenceModelTests.Inheritance.cs
+++ b/src/FluentNHibernate.Testing/AutoMapping/Apm/AutoPersistenceModelTests.Inheritance.cs
@@ -182,7 +182,6 @@ namespace FluentNHibernate.Testing.AutoMapping.Apm
         public void TestInheritanceOverridingMappingProperties()
         {
             var autoMapper = AutoMap.AssemblyOf<ExampleClass>()
-                .Override<ExampleClass>(t => t.JoinedSubClass<ExampleInheritedClass>("OverridenKey", p => p.Map(c => c.ExampleProperty, "columnName")))
                 .Where(t => t.Namespace == "FluentNHibernate.Automapping.TestFixtures");
 
             new AutoMappingTester<ExampleClass>(autoMapper)
@@ -194,8 +193,7 @@ namespace FluentNHibernate.Testing.AutoMapping.Apm
         public void TestInheritanceSubclassOverridingMappingProperties()
         {
             var autoMapper = AutoMap.AssemblyOf<ExampleClass>()
-                .Setup(x => x.IsDiscriminated = type => true)
-                .Override<ExampleClass>(t => t.SubClass<ExampleInheritedClass>("discriminator", p => p.Map(c => c.ExampleProperty, "columnName")))
+                .Override<ExampleClass>(t => t.DiscriminateSubClassesOnColumn("discriminator"))
                 .Where(t => t.Namespace == "FluentNHibernate.Automapping.TestFixtures");
 
             new AutoMappingTester<ExampleClass>(autoMapper)

--- a/src/FluentNHibernate.Testing/AutoMapping/Apm/AutoPersistenceModelTests.Overrides.cs
+++ b/src/FluentNHibernate.Testing/AutoMapping/Apm/AutoPersistenceModelTests.Overrides.cs
@@ -203,6 +203,17 @@ namespace FluentNHibernate.Testing.AutoMapping.Apm
         }
 
         [Test]
+        public void JoinedSubclassOverrideShouldOverrideKeyColumn()
+        {
+            var autoMapper = AutoMap.AssemblyOf<ExampleClass>()
+                .Where(t => t.Namespace == "FluentNHibernate.Automapping.TestFixtures")
+                .Override<ExampleInheritedClass>(m => m.KeyColumn("MyKey"));
+
+            new AutoMappingTester<ExampleClass>(autoMapper)
+                .Element("//joined-subclass/key/column").HasAttribute("name", "MyKey");
+        }
+
+        [Test]
         public void JoinedSubclassOverrideShouldOverrideExistingHasOne()
         {
             var autoMapper = AutoMap.AssemblyOf<ExampleClass>()

--- a/src/FluentNHibernate/Automapping/AutoMapping.cs
+++ b/src/FluentNHibernate/Automapping/AutoMapping.cs
@@ -212,5 +212,24 @@ namespace FluentNHibernate.Automapping
             return null;
         }
 #pragma warning restore 809
+
+        /// <summary>
+        /// Adds a column to the key for this subclass, if used
+        /// in a table-per-subclass strategy.
+        /// </summary>
+        /// <param name="column">Column name</param>
+        public void KeyColumn(string column)
+        {
+            KeyMapping key;
+
+            if (attributes.IsSpecified("Key"))
+                key = attributes.GetOrDefault<KeyMapping>("Key");
+            else
+                key = new KeyMapping();
+
+            key.AddColumn(Layer.UserSupplied, new ColumnMapping(column));
+
+            attributes.Set("Key", Layer.UserSupplied, key);
+        }
     }
 }

--- a/src/FluentNHibernate/Automapping/AutoMapping.cs
+++ b/src/FluentNHibernate/Automapping/AutoMapping.cs
@@ -128,6 +128,7 @@ namespace FluentNHibernate.Automapping
             return this;
         }
 
+        [Obsolete("Inline definitions of subclasses are depreciated. Please create a derived class from SubclassMap in the same way you do with ClassMap.")]
         public AutoJoinedSubClassPart<TSubclass> JoinedSubClass<TSubclass>(string keyColumn, Action<AutoJoinedSubClassPart<TSubclass>> action)
             where TSubclass : T
         {
@@ -142,6 +143,7 @@ namespace FluentNHibernate.Automapping
             return joinedclass;
         }
 
+        [Obsolete("Inline definitions of subclasses are depreciated. Please create a derived class from SubclassMap in the same way you do with ClassMap.")]
         public IAutoClasslike JoinedSubClass(Type type, string keyColumn)
         {
             var genericType = typeof (AutoJoinedSubClassPart<>).MakeGenericType(type);
@@ -153,12 +155,14 @@ namespace FluentNHibernate.Automapping
             return (IAutoClasslike)joinedclass;
         }
 
+        [Obsolete("Inline definitions of subclasses are depreciated. Please create a derived class from SubclassMap in the same way you do with ClassMap.")]
         public AutoJoinedSubClassPart<TSubclass> JoinedSubClass<TSubclass>(string keyColumn)
             where TSubclass : T
         {
             return JoinedSubClass<TSubclass>(keyColumn, null);
         }
 
+        [Obsolete("Inline definitions of subclasses are depreciated. Please create a derived class from SubclassMap in the same way you do with ClassMap.")]
         public AutoSubClassPart<TSubclass> SubClass<TSubclass>(object discriminatorValue, Action<AutoSubClassPart<TSubclass>> action)
             where TSubclass : T
         {
@@ -174,12 +178,14 @@ namespace FluentNHibernate.Automapping
             return subclass;
         }
 
+        [Obsolete("Inline definitions of subclasses are depreciated. Please create a derived class from SubclassMap in the same way you do with ClassMap.")]
         public AutoSubClassPart<TSubclass> SubClass<TSubclass>(object discriminatorValue)
             where TSubclass : T
         {
             return SubClass<TSubclass>(discriminatorValue, null);
         }
 
+        [Obsolete("Inline definitions of subclasses are depreciated. Please create a derived class from SubclassMap in the same way you do with ClassMap.")]
         public IAutoClasslike SubClass(Type type, string discriminatorValue)
         {
             var genericType = typeof(AutoSubClassPart<>).MakeGenericType(type);

--- a/src/FluentNHibernate/Automapping/IAutoClasslike.cs
+++ b/src/FluentNHibernate/Automapping/IAutoClasslike.cs
@@ -6,7 +6,9 @@ namespace FluentNHibernate.Automapping
     public interface IAutoClasslike : IMappingProvider
     {
         void DiscriminateSubClassesOnColumn(string column);
+        [Obsolete("Inline definitions of subclasses are depreciated. Please create a derived class from SubclassMap in the same way you do with ClassMap.")]
         IAutoClasslike JoinedSubClass(Type type, string keyColumn);
+        [Obsolete("Inline definitions of subclasses are depreciated. Please create a derived class from SubclassMap in the same way you do with ClassMap.")]
         IAutoClasslike SubClass(Type type, string discriminatorValue);
         void AlterModel(ClassMappingBase mapping);
     }


### PR DESCRIPTION
```csharp
var autoMapper = AutoMap.AssemblyOf<ExampleClass>()
    .Where(t => t.Namespace == "FluentNHibernate.Automapping.TestFixtures")
    .Override<ExampleInheritedClass>(m => m.KeyColumn("MyKey")); // ExampleInheritedClass is joined-subclass
```

Closes #42 