### PR TITLE
Adding PostgreSQL 8.3 dialect

### DIFF
--- a/src/FluentNHibernate.Testing/Cfg/Db/PostgreSQLConfigurationTester.cs
+++ b/src/FluentNHibernate.Testing/Cfg/Db/PostgreSQLConfigurationTester.cs
@@ -36,6 +36,13 @@ namespace FluentNHibernate.Testing.Cfg.Db
         }
 
         [Test]
+        public void PostgreSQL_83_should_set_the_correct_dialect()
+        {
+            PostgreSQLConfiguration.PostgreSQL83.ToProperties()["dialect"].ShouldEqual(
+                "NHibernate.Dialect.PostgreSQL83Dialect, " + typeof(ISession).Assembly.FullName);
+        }
+
+        [Test]
         public void ConnectionString_is_added_to_the_configuration()
         {
             PostgreSQLConfiguration.PostgreSQL82

--- a/src/FluentNHibernate/Cfg/Db/PostgreSQLConfiguration.cs
+++ b/src/FluentNHibernate/Cfg/Db/PostgreSQLConfiguration.cs
@@ -24,5 +24,10 @@ namespace FluentNHibernate.Cfg.Db
         {
             get { return new PostgreSQLConfiguration().Dialect<PostgreSQL82Dialect>(); }
         }
+
+        public static PostgreSQLConfiguration PostgreSQL83
+        {
+            get { return new PostgreSQLConfiguration().Dialect<PostgreSQL83Dialect>(); }
+        }
     }
 }


### PR DESCRIPTION
This would let people specify the `Postgres83Dialect` when configuring their `ISessionFactory` using `FluentNHibernate`.

The [Postgres83Dialect](https://github.com/nhibernate/nhibernate-core/blob/master/src/NHibernate/Dialect/PostgreSQL83Dialect.cs) in NHibernate just adds support for the [PostgreSQL XML datatype](https://www.postgresql.org/docs/8.3/static/datatype-xml.html):

```csharp
	/// <summary>
	/// An SQL dialect for PostgreSQL 8.3 and above.
	/// </summary>
	/// <remarks>
	/// PostgreSQL 8.3 supports xml type
	/// </remarks>
	public class PostgreSQL83Dialect : PostgreSQL82Dialect
	{
		public PostgreSQL83Dialect()
		{
			//https://www.postgresql.org/docs/8.3/static/datatype-xml.html
			RegisterColumnType(DbType.Xml, "xml");
		}
	}
```