### PR TITLE
correct gitattributes to disable autocrlf

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-[core]
-autocrlf=false
+# Disable core.autocrlf by marking all files as NOT being text
+* -text


### PR DESCRIPTION
Update `gitattributes` as per https://stackoverflow.com/a/52996849

Old `gitattributes` used the `.gitconfig` syntax which is different to `.gitattributes`

Not sure why we need to disable autocrlf though? The repo has a few files with inconsistent line endings that VS complains about. Could we normalize the line endings and then enable `autocrlf`? This would be a more standard configuration and stop VS from complaining about mixed line endings. Happy to open a PR for this.