### PR TITLE
Update NuGet dotnet version to 6 and 8 and remove .netcoreapp2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ dotnet add package FluentNHibernate
 
 * Read the [introduction](https://github.com/FluentNHibernate/fluent-nhibernate/wiki/Getting-started).
 * Get latest version from NuGet
-    - [.NETCore2.0, NETStandard2.0 or NET 4.6.1 with NHibernate 5.x](https://www.nuget.org/packages/FluentNHibernate)
+    - [.NET 6.0, .NET 8.0, NETStandard2.0 or NET 4.6.1 with NHibernate 5.x](https://www.nuget.org/packages/FluentNHibernate)
     - [.NET 4.0 with NHibernate 4.x](https://www.nuget.org/packages/FluentNHibernate/2.0.3)
     - [.NET 3.5 with NHibernate 3 if you like it vintage](https://www.nuget.org/packages/FluentNHibernate.Net35)
 

--- a/build.cake
+++ b/build.cake
@@ -120,8 +120,15 @@ Task("Copy-Files")
             msBuildSettings
         );
         PublishProjects(
-            SrcProjects, "netcoreapp2.0",
-            parameters.Paths.Directories.ArtifactsBinNetCoreApp2.FullPath, 
+            SrcProjects, "net6.0",
+            parameters.Paths.Directories.ArtifactsBinNet60.FullPath, 
+            parameters.Version.DotNetAsterix, 
+            parameters.Configuration, 
+            msBuildSettings
+        );
+        PublishProjects(
+            SrcProjects, "net8.0",
+            parameters.Paths.Directories.ArtifactsBinNet80.FullPath, 
             parameters.Version.DotNetAsterix, 
             parameters.Configuration, 
             msBuildSettings

--- a/build/paths.cake
+++ b/build/paths.cake
@@ -25,7 +25,8 @@ public class BuildPaths
         var artifactsBinDir = artifactsDir.Combine("bin");
         var artifactsBinFullFx = artifactsBinDir.Combine("net461");        
         var artifactsBinNetStandard20 = artifactsBinDir.Combine("netstandard2.0");        
-        var artifactsBinNetCoreapp2 = artifactsBinDir.Combine("netcoreapp2.0");        
+        var artifactsBinNet60 = artifactsBinDir.Combine("netstandard6.0");        
+        var artifactsBinNet80 = artifactsBinDir.Combine("netstandard8.0");        
         var testResultsDir = artifactsDir.Combine("test-results");
         var nugetRoot = artifactsDir.Combine("nuget");
         
@@ -39,7 +40,8 @@ public class BuildPaths
             artifactsBinDir,
             artifactsBinFullFx,
             artifactsBinNetStandard20,
-            artifactsBinNetCoreapp2);
+            artifactsBinNet60,
+            artifactsBinNet80);
 
         // Files
         var buildFiles = new BuildFiles(
@@ -74,7 +76,8 @@ public class BuildDirectories
     public DirectoryPath ArtifactsBin { get; private set; }
     public DirectoryPath ArtifactsBinFullFx { get; private set; }    
     public DirectoryPath ArtifactsBinNetStandard20 { get; private set; }    
-    public DirectoryPath ArtifactsBinNetCoreApp2 { get; private set; }    
+    public DirectoryPath ArtifactsBinNet60 { get; private set; }    
+    public DirectoryPath ArtifactsBinNet80 { get; private set; }    
     public ICollection<DirectoryPath> ToClean { get; private set; }
 
     public BuildDirectories(        
@@ -84,7 +87,8 @@ public class BuildDirectories
         DirectoryPath artifactsBinDir,
         DirectoryPath artifactsBinFullFx,
         DirectoryPath artifactsBinNetStandard20,
-        DirectoryPath artifactsBinNetCoreapp2
+        DirectoryPath artifactsNet60,
+        DirectoryPath artifactsNet80
         )
     {
         Artifacts = artifactsDir;
@@ -93,7 +97,9 @@ public class BuildDirectories
         ArtifactsBin = artifactsBinDir;
         ArtifactsBinFullFx = artifactsBinFullFx;        
         ArtifactsBinNetStandard20 = artifactsBinNetStandard20;
-        ArtifactsBinNetCoreApp2 = artifactsBinNetCoreapp2;
+        ArtifactsBinNet60 = artifactsNet60;
+        ArtifactsBinNet80 = artifactsNet80;
+
         ToClean = new[] {
             Artifacts,
             TestResults,

--- a/src/FluentNHibernate/FluentNHibernate.csproj
+++ b/src/FluentNHibernate/FluentNHibernate.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461;net6.0;net8.0</TargetFrameworks>
     <PlatformTarget>AnyCpu</PlatformTarget>
     <OutputType>Library</OutputType>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -10,10 +10,6 @@
     <AssemblyOriginatorKeyFile>../FluentKey.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
-    <RuntimeFrameworkVersion>2.0.9</RuntimeFrameworkVersion>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="NHibernate" Version="5.3.3" />
   </ItemGroup>


### PR DESCRIPTION
Update the NuGet package to provide libraries for .NET 6.0 and 8.0. Also removed .NET Core 2.0 as it went EOL in 2018 (almost 6 years ago).

`build.ps1` runs locally and the generated nuget package contains the .NET 6/8 packages
![image](https://github.com/nhibernate/fluent-nhibernate/assets/42630535/8863361e-d01a-41d7-96dd-57af44b55404)

I didn't add support for .NET 7.0 as it'll go EOL very soon (May this year). Let me know if you'd like to support it and I can add it in.

Adding later versions of .NET lets us use classes/functions such as `Span` or `SearchValues`.