### PR TITLE
Add Nullable to Automapping

### DIFF
--- a/src/FluentNHibernate/Automapping/Alterations/AutoMappingOverrideAlteration.cs
+++ b/src/FluentNHibernate/Automapping/Alterations/AutoMappingOverrideAlteration.cs
@@ -1,3 +1,6 @@
+#if USE_NULLABLE
+#nullable enable
+#endif
 using System.Linq;
 using System.Reflection;
 

--- a/src/FluentNHibernate/Automapping/Alterations/IAutoMappingAlteration.cs
+++ b/src/FluentNHibernate/Automapping/Alterations/IAutoMappingAlteration.cs
@@ -1,4 +1,7 @@
-﻿namespace FluentNHibernate.Automapping.Alterations;
+﻿#if USE_NULLABLE
+#nullable enable
+#endif
+namespace FluentNHibernate.Automapping.Alterations;
 
 /// <summary>
 /// Provides a mechanism for altering an AutoPersistenceModel prior to

--- a/src/FluentNHibernate/Automapping/Alterations/IAutoMappingOverride.cs
+++ b/src/FluentNHibernate/Automapping/Alterations/IAutoMappingOverride.cs
@@ -1,4 +1,7 @@
-﻿namespace FluentNHibernate.Automapping.Alterations;
+﻿#if USE_NULLABLE
+#nullable enable
+#endif
+namespace FluentNHibernate.Automapping.Alterations;
 
 /// <summary>
 /// A mapping override for an auto mapped entity.

--- a/src/FluentNHibernate/Automapping/AutoJoinPart.cs
+++ b/src/FluentNHibernate/Automapping/AutoJoinPart.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿#if USE_NULLABLE
+#nullable enable
+#endif
+using System.Collections.Generic;
 using FluentNHibernate.Mapping;
 
 namespace FluentNHibernate.Automapping;

--- a/src/FluentNHibernate/Automapping/AutoJoinedSubClassPart.cs
+++ b/src/FluentNHibernate/Automapping/AutoJoinedSubClassPart.cs
@@ -1,3 +1,6 @@
+#if USE_NULLABLE
+#nullable enable
+#endif
 using System;
 using System.Collections.Generic;
 using FluentNHibernate.Mapping;
@@ -44,7 +47,7 @@ public class AutoJoinedSubClassPart<T> : JoinedSubClassPart<T>, IAutoClasslike
     public void JoinedSubClass<TSubclass>(string keyColumn, Action<AutoJoinedSubClassPart<TSubclass>> action)
     {
         var genericType = typeof(AutoJoinedSubClassPart<>).MakeGenericType(typeof(TSubclass));
-        var joinedclass = (AutoJoinedSubClassPart<TSubclass>)Activator.CreateInstance(genericType, keyColumn);
+        var joinedclass = (AutoJoinedSubClassPart<TSubclass>)Activator.CreateInstance(genericType, keyColumn)!;
 
         action(joinedclass);
 
@@ -54,7 +57,7 @@ public class AutoJoinedSubClassPart<T> : JoinedSubClassPart<T>, IAutoClasslike
     public IAutoClasslike JoinedSubClass(Type type, string keyColumn)
     {
         var genericType = typeof(AutoJoinedSubClassPart<>).MakeGenericType(type);
-        var joinedclass = (ISubclassMappingProvider)Activator.CreateInstance(genericType, keyColumn);
+        var joinedclass = (ISubclassMappingProvider)Activator.CreateInstance(genericType, keyColumn)!;
 
         providers.Subclasses[type] = joinedclass;
 
@@ -64,7 +67,7 @@ public class AutoJoinedSubClassPart<T> : JoinedSubClassPart<T>, IAutoClasslike
     public void SubClass<TSubclass>(string discriminatorValue, Action<AutoSubClassPart<TSubclass>> action)
     {
         var genericType = typeof(AutoSubClassPart<>).MakeGenericType(typeof(TSubclass));
-        var subclass = (AutoSubClassPart<TSubclass>)Activator.CreateInstance(genericType, discriminatorValue);
+        var subclass = (AutoSubClassPart<TSubclass>)Activator.CreateInstance(genericType, discriminatorValue)!;
 
         action(subclass);
 
@@ -74,19 +77,19 @@ public class AutoJoinedSubClassPart<T> : JoinedSubClassPart<T>, IAutoClasslike
     public IAutoClasslike SubClass(Type type, string discriminatorValue)
     {
         var genericType = typeof(AutoSubClassPart<>).MakeGenericType(type);
-        var subclass = (ISubclassMappingProvider)Activator.CreateInstance(genericType, discriminatorValue);
+        var subclass = (ISubclassMappingProvider)Activator.CreateInstance(genericType, discriminatorValue)!;
 
         providers.Subclasses[type] = subclass;
 
         return (IAutoClasslike)subclass;
     }
 
-    public ClassMapping GetClassMapping()
+    public ClassMapping? GetClassMapping()
     {
         return null;
     }
 
-    public HibernateMapping GetHibernateMapping()
+    public HibernateMapping? GetHibernateMapping()
     {
         return null;
     }

--- a/src/FluentNHibernate/Automapping/AutoMap.cs
+++ b/src/FluentNHibernate/Automapping/AutoMap.cs
@@ -1,3 +1,6 @@
+#if USE_NULLABLE
+#nullable enable
+#endif
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/FluentNHibernate/Automapping/AutoMapType.cs
+++ b/src/FluentNHibernate/Automapping/AutoMapType.cs
@@ -1,3 +1,6 @@
+#if USE_NULLABLE
+#nullable enable
+#endif
 using System;
 
 namespace FluentNHibernate.Automapping;

--- a/src/FluentNHibernate/Automapping/AutoMapping.cs
+++ b/src/FluentNHibernate/Automapping/AutoMapping.cs
@@ -1,3 +1,6 @@
+#if USE_NULLABLE
+#nullable enable
+#endif
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -107,7 +110,7 @@ public class AutoMapping<T> : ClassMap<T>, IAutoClasslike, IPropertyIgnorer
         return this;
     }
 
-    IPropertyIgnorer IPropertyIgnorer.IgnoreProperties(string first, params string[] others)
+    IPropertyIgnorer IPropertyIgnorer.IgnoreProperties(string first, params string[]? others)
     {
         var options = (others ?? Array.Empty<string>()).Concat(new[] { first }).ToArray();
 
@@ -127,11 +130,11 @@ public class AutoMapping<T> : ClassMap<T>, IAutoClasslike, IPropertyIgnorer
     }
 
     [Obsolete("Inline definitions of subclasses are depreciated. Please create a derived class from SubclassMap in the same way you do with ClassMap.")]
-    public AutoJoinedSubClassPart<TSubclass> JoinedSubClass<TSubclass>(string keyColumn, Action<AutoJoinedSubClassPart<TSubclass>> action)
+    public AutoJoinedSubClassPart<TSubclass> JoinedSubClass<TSubclass>(string keyColumn, Action<AutoJoinedSubClassPart<TSubclass>>? action)
         where TSubclass : T
     {
         var genericType = typeof(AutoJoinedSubClassPart<>).MakeGenericType(typeof(TSubclass));
-        var joinedclass = (AutoJoinedSubClassPart<TSubclass>)Activator.CreateInstance(genericType, keyColumn);
+        var joinedclass = (AutoJoinedSubClassPart<TSubclass>)Activator.CreateInstance(genericType, keyColumn)!;
 
         action?.Invoke(joinedclass);
 
@@ -144,7 +147,7 @@ public class AutoMapping<T> : ClassMap<T>, IAutoClasslike, IPropertyIgnorer
     public IAutoClasslike JoinedSubClass(Type type, string keyColumn)
     {
         var genericType = typeof (AutoJoinedSubClassPart<>).MakeGenericType(type);
-        var joinedclass = (ISubclassMappingProvider)Activator.CreateInstance(genericType, keyColumn);
+        var joinedclass = (ISubclassMappingProvider)Activator.CreateInstance(genericType, keyColumn)!;
 
         // remove any mappings for the same type, then re-add
         providers.Subclasses[type] = joinedclass;
@@ -160,11 +163,11 @@ public class AutoMapping<T> : ClassMap<T>, IAutoClasslike, IPropertyIgnorer
     }
 
     [Obsolete("Inline definitions of subclasses are depreciated. Please create a derived class from SubclassMap in the same way you do with ClassMap.")]
-    public AutoSubClassPart<TSubclass> SubClass<TSubclass>(object discriminatorValue, Action<AutoSubClassPart<TSubclass>> action)
+    public AutoSubClassPart<TSubclass> SubClass<TSubclass>(object discriminatorValue, Action<AutoSubClassPart<TSubclass>>? action)
         where TSubclass : T
     {
         var genericType = typeof(AutoSubClassPart<>).MakeGenericType(typeof(TSubclass));
-        var subclass = (AutoSubClassPart<TSubclass>)Activator.CreateInstance(genericType, null, discriminatorValue);
+        var subclass = (AutoSubClassPart<TSubclass>)Activator.CreateInstance(genericType, null, discriminatorValue)!;
 
         action?.Invoke(subclass);
 
@@ -185,7 +188,7 @@ public class AutoMapping<T> : ClassMap<T>, IAutoClasslike, IPropertyIgnorer
     public IAutoClasslike SubClass(Type type, string discriminatorValue)
     {
         var genericType = typeof(AutoSubClassPart<>).MakeGenericType(type);
-        var subclass = (ISubclassMappingProvider)Activator.CreateInstance(genericType, null, discriminatorValue);
+        var subclass = (ISubclassMappingProvider)Activator.CreateInstance(genericType, null, discriminatorValue)!;
 
         // remove any mappings for the same type, then re-add
         providers.Subclasses[type] = subclass;
@@ -194,7 +197,7 @@ public class AutoMapping<T> : ClassMap<T>, IAutoClasslike, IPropertyIgnorer
     }
 
     // hide the base one D:
-    new void Join(string table, Action<JoinPart<T>> action)
+    new void Join(string? table, Action<JoinPart<T>>? action)
     {}
 
     public void Join(string table, Action<AutoJoinPart<T>> action)
@@ -209,7 +212,7 @@ public class AutoMapping<T> : ClassMap<T>, IAutoClasslike, IPropertyIgnorer
 #pragma warning disable 809
     // hide this - imports aren't supported in overrides
     [Obsolete("Imports aren't supported in overrides.", true)]
-    public new ImportPart ImportType<TImport>()
+    public new ImportPart? ImportType<TImport>()
     {
         return null;
     }

--- a/src/FluentNHibernate/Automapping/AutoMappingAlterationCollection.cs
+++ b/src/FluentNHibernate/Automapping/AutoMappingAlterationCollection.cs
@@ -1,3 +1,6 @@
+#if USE_NULLABLE
+#nullable enable
+#endif
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -16,7 +19,7 @@ public class AutoMappingAlterationCollection : IEnumerable<IAutoMappingAlteratio
     /// <param name="type">Type of an IAutoMappingAlteration</param>
     void Add(Type type)
     {
-        Add((IAutoMappingAlteration)Activator.CreateInstance(type));
+        Add((IAutoMappingAlteration)Activator.CreateInstance(type)!);
     }
 
     /// <summary>

--- a/src/FluentNHibernate/Automapping/AutoMappingException.cs
+++ b/src/FluentNHibernate/Automapping/AutoMappingException.cs
@@ -1,3 +1,6 @@
+#if USE_NULLABLE
+#nullable enable
+#endif
 using System;
 using System.Runtime.Serialization;
 

--- a/src/FluentNHibernate/Automapping/AutoMappingExpressions.cs
+++ b/src/FluentNHibernate/Automapping/AutoMappingExpressions.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿#if USE_NULLABLE
+#nullable enable
+#endif
+using System;
 
 namespace FluentNHibernate.Automapping;
 
@@ -8,51 +11,51 @@ public class AutoMappingExpressions
     /// Determines whether a member is to be automapped. 
     /// </summary>
     [Obsolete("Use an instance of IAutomappingConfiguration for configuration, and override ShouldMap(Member)")]
-    public Func<Member, bool> FindMembers;
+    public Func<Member, bool>? FindMembers;
 
     /// <summary>
     /// Determines whether a member is the identity of an entity.
     /// </summary>
     [Obsolete("Use an instance of IAutomappingConfiguration for configuration, and override IsId")]
-    public Func<Member, bool> FindIdentity;
+    public Func<Member, bool>? FindIdentity;
 
     [Obsolete("Use an instance of IAutomappingConfiguration for configuration, and override GetParentSideForManyToMany")]
-    public Func<Type, Type, Type> GetParentSideForManyToMany;
+    public Func<Type, Type, Type>? GetParentSideForManyToMany;
 
     [Obsolete("Use IgnoreBase<T> or IgnoreBase(Type): AutoMap.AssemblyOf<Entity>().IgnoreBase(typeof(Parent<>))", true)]
-    public Func<Type, bool> IsBaseType;
+    public Func<Type, bool>? IsBaseType;
 
     [Obsolete("Use an instance of IAutomappingConfiguration for configuration, and override IsConcreteBaseType")]
-    public Func<Type, bool> IsConcreteBaseType;
+    public Func<Type?, bool>? IsConcreteBaseType;
         
     [Obsolete("Use an instance of IAutomappingConfiguration for configuration, and override IsComponent")]
-    public Func<Type, bool> IsComponentType;
+    public Func<Type, bool>? IsComponentType;
 
     [Obsolete("Use an instance of IAutomappingConfiguration for configuration, and override GetComponentColumnPrefix")]
-    public Func<Member, string> GetComponentColumnPrefix;
+    public Func<Member, string>? GetComponentColumnPrefix;
 
     [Obsolete("Use an instance of IAutomappingConfiguration for configuration, and override IsDiscriminated")]
-    public Func<Type, bool> IsDiscriminated;
+    public Func<Type, bool>? IsDiscriminated;
 
     [Obsolete("Use an instance of IAutomappingConfiguration for configuration, and override GetDiscriminatorColumn")]
-    public Func<Type, string> DiscriminatorColumn;
+    public Func<Type, string>? DiscriminatorColumn;
 
 #pragma warning disable 612,618
     [Obsolete("Use an instance of IAutomappingConfiguration for configuration, and override IsDiscriminated", true)]
-    public Func<Type, SubclassStrategy> SubclassStrategy;
+    public Func<Type, SubclassStrategy>? SubclassStrategy;
 #pragma warning restore 612,618
 
     /// <summary>
     /// Determines whether an abstract class is a layer supertype or part of a mapped inheritance hierarchy.
     /// </summary>
     [Obsolete("Use an instance of IAutomappingConfiguration for configuration, and override AbstractClassIsLayerSupertype")]
-    public Func<Type, bool> AbstractClassIsLayerSupertype;
+    public Func<Type, bool>? AbstractClassIsLayerSupertype;
 
     /// <summary>
     /// Specifies the value column used in a table of simple types. 
     /// </summary>
     [Obsolete("Use an instance of IAutomappingConfiguration for configuration, and override SimpleTypeCollectionValueColumn")]
-    public Func<Member, string> SimpleTypeCollectionValueColumn;
+    public Func<Member, string>? SimpleTypeCollectionValueColumn;
 }
 
 #pragma warning disable 612,618
@@ -85,7 +88,7 @@ class ExpressionBasedAutomappingConfiguration(AutoMappingExpressions expressions
         return base.GetParentSideForManyToMany(left, right);
     }
 
-    public override bool IsConcreteBaseType(Type type)
+    public override bool IsConcreteBaseType(Type? type)
     {
         if (expressions.IsConcreteBaseType is not null)
             return expressions.IsConcreteBaseType(type);

--- a/src/FluentNHibernate/Automapping/AutoSubClassPart.cs
+++ b/src/FluentNHibernate/Automapping/AutoSubClassPart.cs
@@ -1,3 +1,6 @@
+#if USE_NULLABLE
+#nullable enable
+#endif
 using System;
 using System.Collections.Generic;
 using FluentNHibernate.Mapping;
@@ -48,7 +51,7 @@ public class AutoSubClassPart<T> : SubClassPart<T>, IAutoClasslike
     public void JoinedSubClass<TSubclass>(string keyColumn, Action<AutoJoinedSubClassPart<TSubclass>> action)
     {
         var genericType = typeof(AutoJoinedSubClassPart<>).MakeGenericType(typeof(TSubclass));
-        var joinedclass = (AutoJoinedSubClassPart<TSubclass>)Activator.CreateInstance(genericType, keyColumn);
+        var joinedclass = (AutoJoinedSubClassPart<TSubclass>)Activator.CreateInstance(genericType, keyColumn)!;
 
         action(joinedclass);
 
@@ -58,7 +61,7 @@ public class AutoSubClassPart<T> : SubClassPart<T>, IAutoClasslike
     public IAutoClasslike JoinedSubClass(Type type, string keyColumn)
     {
         var genericType = typeof(AutoJoinedSubClassPart<>).MakeGenericType(type);
-        var joinedclass = (ISubclassMappingProvider)Activator.CreateInstance(genericType, keyColumn);
+        var joinedclass = (ISubclassMappingProvider)Activator.CreateInstance(genericType, keyColumn)!;
 
         providers.Subclasses[type] = joinedclass;
 
@@ -68,7 +71,7 @@ public class AutoSubClassPart<T> : SubClassPart<T>, IAutoClasslike
     public void SubClass<TSubclass>(string discriminatorValue, Action<AutoSubClassPart<TSubclass>> action)
     {
         var genericType = typeof(AutoSubClassPart<>).MakeGenericType(typeof(TSubclass));
-        var subclass = (AutoSubClassPart<TSubclass>)Activator.CreateInstance(genericType, discriminatorValue);
+        var subclass = (AutoSubClassPart<TSubclass>)Activator.CreateInstance(genericType, discriminatorValue)!;
 
         action?.Invoke(subclass);
 
@@ -78,19 +81,19 @@ public class AutoSubClassPart<T> : SubClassPart<T>, IAutoClasslike
     public IAutoClasslike SubClass(Type type, string discriminatorValue)
     {
         var genericType = typeof(AutoSubClassPart<>).MakeGenericType(type);
-        var subclass = (ISubclassMappingProvider)Activator.CreateInstance(genericType, discriminatorValue);
+        var subclass = (ISubclassMappingProvider)Activator.CreateInstance(genericType, discriminatorValue)!;
 
         providers.Subclasses[type] = subclass;
 
         return (IAutoClasslike)subclass;
     }
 
-    public ClassMapping GetClassMapping()
+    public ClassMapping? GetClassMapping()
     {
         return null;
     }
 
-    public HibernateMapping GetHibernateMapping()
+    public HibernateMapping? GetHibernateMapping()
     {
         return null;
     }

--- a/src/FluentNHibernate/Automapping/DefaultAutomappingConfiguration.cs
+++ b/src/FluentNHibernate/Automapping/DefaultAutomappingConfiguration.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿#if USE_NULLABLE
+#nullable enable
+#endif
+using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using FluentNHibernate.Automapping.Alterations;
@@ -37,10 +40,10 @@ public class DefaultAutomappingConfiguration : IAutomappingConfiguration
 
     public virtual Type GetParentSideForManyToMany(Type left, Type right)
     {
-        return left.FullName.CompareTo(right.FullName) < 0 ? left : right;
+        return string.Compare(left.FullName, right.FullName) < 0 ? left : right;
     }
 
-    public virtual bool IsConcreteBaseType(Type type)
+    public virtual bool IsConcreteBaseType(Type? type)
     {
         return false;
     }

--- a/src/FluentNHibernate/Automapping/IAutoClasslike.cs
+++ b/src/FluentNHibernate/Automapping/IAutoClasslike.cs
@@ -1,3 +1,6 @@
+#if USE_NULLABLE
+#nullable enable
+#endif
 using System;
 using FluentNHibernate.MappingModel.ClassBased;
 

--- a/src/FluentNHibernate/Automapping/IAutomappingConfiguration.cs
+++ b/src/FluentNHibernate/Automapping/IAutomappingConfiguration.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿#if USE_NULLABLE
+#nullable enable
+#endif
+using System;
 using System.Collections.Generic;
 using FluentNHibernate.Automapping.Steps;
 using FluentNHibernate.Conventions;
@@ -80,7 +83,7 @@ public interface IAutomappingConfiguration
     /// </summary>
     /// <param name="type">Type</param>
     /// <returns>Base type is concrete?</returns>
-    bool IsConcreteBaseType(Type type);
+    bool IsConcreteBaseType(Type? type);
 
     /// <summary>
     /// Specifies that a particular type should be mapped as a component rather than

--- a/src/FluentNHibernate/Automapping/IPropertyIgnorer.cs
+++ b/src/FluentNHibernate/Automapping/IPropertyIgnorer.cs
@@ -1,3 +1,6 @@
+#if USE_NULLABLE
+#nullable enable
+#endif
 using System;
 
 namespace FluentNHibernate.Automapping;

--- a/src/FluentNHibernate/Automapping/InlineOverride.cs
+++ b/src/FluentNHibernate/Automapping/InlineOverride.cs
@@ -1,3 +1,6 @@
+#if USE_NULLABLE
+#nullable enable
+#endif
 using System;
 
 namespace FluentNHibernate.Automapping;

--- a/src/FluentNHibernate/Automapping/PrivateAutoPersistenceModel.cs
+++ b/src/FluentNHibernate/Automapping/PrivateAutoPersistenceModel.cs
@@ -1,3 +1,6 @@
+#if USE_NULLABLE
+#nullable enable
+#endif
 using System;
 
 namespace FluentNHibernate.Automapping;

--- a/src/FluentNHibernate/Automapping/Steps/AutoKeyMapper.cs
+++ b/src/FluentNHibernate/Automapping/Steps/AutoKeyMapper.cs
@@ -1,4 +1,7 @@
-﻿using FluentNHibernate.MappingModel;
+﻿#if USE_NULLABLE
+#nullable enable
+#endif
+using FluentNHibernate.MappingModel;
 using FluentNHibernate.MappingModel.ClassBased;
 using FluentNHibernate.MappingModel.Collections;
 

--- a/src/FluentNHibernate/Automapping/Steps/CollectionStep.cs
+++ b/src/FluentNHibernate/Automapping/Steps/CollectionStep.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections;
+﻿#if USE_NULLABLE
+#nullable enable
+#endif
+using System.Collections;
 using System.Collections.Generic;
 using FluentNHibernate.Mapping;
 using FluentNHibernate.MappingModel;

--- a/src/FluentNHibernate/Automapping/Steps/ComponentStep.cs
+++ b/src/FluentNHibernate/Automapping/Steps/ComponentStep.cs
@@ -1,4 +1,7 @@
-﻿using FluentNHibernate.MappingModel.ClassBased;
+﻿#if USE_NULLABLE
+#nullable enable
+#endif
+using FluentNHibernate.MappingModel.ClassBased;
 
 namespace FluentNHibernate.Automapping.Steps;
 

--- a/src/FluentNHibernate/Automapping/Steps/HasManyStep.cs
+++ b/src/FluentNHibernate/Automapping/Steps/HasManyStep.cs
@@ -1,4 +1,7 @@
-﻿using FluentNHibernate.MappingModel.ClassBased;
+﻿#if USE_NULLABLE
+#nullable enable
+#endif
+using FluentNHibernate.MappingModel.ClassBased;
 
 namespace FluentNHibernate.Automapping.Steps;
 

--- a/src/FluentNHibernate/Automapping/Steps/HasManyToManyStep.cs
+++ b/src/FluentNHibernate/Automapping/Steps/HasManyToManyStep.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿#if USE_NULLABLE
+#nullable enable
+#endif
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -25,7 +28,7 @@ public class HasManyToManyStep(IAutomappingConfiguration cfg) : IAutomappingStep
         return hasInverse;
     }
 
-    static Member GetInverseProperty(Member member)
+    static Member? GetInverseProperty(Member member)
     {
         var type = member.PropertyType;
         var expectedInversePropertyType = type.GetGenericTypeDefinition()
@@ -108,7 +111,7 @@ public class HasManyToManyStep(IAutomappingConfiguration cfg) : IAutomappingStep
 
     public void Map(ClassMappingBase classMap, Member member)
     {
-        var inverseProperty = GetInverseProperty(member);
+        var inverseProperty = GetInverseProperty(member) ?? throw new InvalidOperationException($"Could not determine inverse property of {member}");
         var parentSide = cfg.GetParentSideForManyToMany(member.DeclaringType, inverseProperty.DeclaringType);
         var mapping = GetCollection(member);
 

--- a/src/FluentNHibernate/Automapping/Steps/IAutomappingStep.cs
+++ b/src/FluentNHibernate/Automapping/Steps/IAutomappingStep.cs
@@ -1,4 +1,7 @@
-﻿using FluentNHibernate.MappingModel.ClassBased;
+﻿#if USE_NULLABLE
+#nullable enable
+#endif
+using FluentNHibernate.MappingModel.ClassBased;
 
 namespace FluentNHibernate.Automapping.Steps;
 

--- a/src/FluentNHibernate/Automapping/Steps/IdentityStep.cs
+++ b/src/FluentNHibernate/Automapping/Steps/IdentityStep.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿#if USE_NULLABLE
+#nullable enable
+#endif
+using System;
 using System.Collections.Generic;
 using FluentNHibernate.Mapping;
 using FluentNHibernate.MappingModel;

--- a/src/FluentNHibernate/Automapping/Steps/PropertyStep.cs
+++ b/src/FluentNHibernate/Automapping/Steps/PropertyStep.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿#if USE_NULLABLE
+#nullable enable
+#endif
+using System;
 using System.Linq;
 using FluentNHibernate.Conventions;
 using FluentNHibernate.Conventions.AcceptanceCriteria;

--- a/src/FluentNHibernate/Automapping/Steps/ReferenceStep.cs
+++ b/src/FluentNHibernate/Automapping/Steps/ReferenceStep.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿#if USE_NULLABLE
+#nullable enable
+#endif
+using System;
 using FluentNHibernate.Mapping;
 using FluentNHibernate.MappingModel;
 using FluentNHibernate.MappingModel.ClassBased;

--- a/src/FluentNHibernate/Automapping/Steps/SimpleTypeCollectionStep.cs
+++ b/src/FluentNHibernate/Automapping/Steps/SimpleTypeCollectionStep.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿#if USE_NULLABLE
+#nullable enable
+#endif
+using System;
 using System.Collections.Generic;
 using FluentNHibernate.Mapping;
 using FluentNHibernate.MappingModel;

--- a/src/FluentNHibernate/Automapping/Steps/VersionStep.cs
+++ b/src/FluentNHibernate/Automapping/Steps/VersionStep.cs
@@ -1,4 +1,7 @@
-﻿using FluentNHibernate.Mapping;
+﻿#if USE_NULLABLE
+#nullable enable
+#endif
+using FluentNHibernate.Mapping;
 using FluentNHibernate.MappingModel;
 using FluentNHibernate.MappingModel.ClassBased;
 using FluentNHibernate.Utils;

--- a/src/FluentNHibernate/Automapping/SubclassStrategy.cs
+++ b/src/FluentNHibernate/Automapping/SubclassStrategy.cs
@@ -1,3 +1,6 @@
+#if USE_NULLABLE
+#nullable enable
+#endif
 using System;
 
 namespace FluentNHibernate.Automapping;

--- a/src/FluentNHibernate/FluentNHibernate.csproj
+++ b/src/FluentNHibernate/FluentNHibernate.csproj
@@ -9,6 +9,17 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>../FluentKey.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
+
+  <!--Uncomment nullable, remove Define Constant and the config check once nullable migration is complete -->
+  <PropertyGroup Condition="'$(TargetFramework)'!='netstandard2.0' and '$(TargetFramework)'!='net461' and '$(Configuration)'=='DEBUG'">
+    <DefineConstants>USE_NULLABLE</DefineConstants>
+    <!--<Nullable>enable</Nullable>-->
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)'=='netstandard2.0' or '$(TargetFramework)'=='net461' or '$(Configuration)'!='DEBUG'">
+    <NoWarn>$(NoWarn);CS8632</NoWarn>
+  </PropertyGroup>
+
   
   <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
     <RuntimeFrameworkVersion>2.0.9</RuntimeFrameworkVersion>


### PR DESCRIPTION
This PR begins the process of adding [nullability](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/nullable-reference-types) support to fluent-nhibernate.

Nullable Reference is a compiler feature that provides warning of potential null reference errors. This feature has been enabled by default since .NET Core 6 and many 3rd party libraries have since added support for this feature.

I've began by enabling Nullable in the Automapping folder and resolving any errors. Most of the work was simply adding annotations but I did occasionally have to add a null check or refactor the code to allow the static analyser to determine that something was not nullable. You'll note that there is a few `Activator.CreateInstance(type)!` with the null forgiving operator. `Activator.CreateInstance` will only return a null for nullable value types which we never activate (they're all classes) so it's safe to use the null forgiving operator.

This PR requires #668 to be merged in as .Net framework/standard does not include the nullability attributes in the standard library so we can't add support without adding a third party NuGet library that adds these attributes to the lower versions.

I'm using the pre-processor directive
```
#if USE_NULLABLE
#nullable enable
#endif
```

This allows us to disable nullability for release builds until the migration is complete. Once the migration is complete we can remove the directives.

Let me know if there's any issues with this approach. If there's not I'm happy to migrate the rest of fluent-nhibernate over.