### PR TITLE
Obsolete FluentNHibernate.Data.Entity

### DIFF
--- a/src/FluentNHibernate.Testing/DomainModel/ConnectedTester.cs
+++ b/src/FluentNHibernate.Testing/DomainModel/ConnectedTester.cs
@@ -106,8 +106,9 @@ public sealed class NestedSubClassMap : ClassMap<SuperRecord>
 
 #pragma warning restore 612, 618
 
-public class SuperRecord  : Entity
+public class SuperRecord
 {
+    public virtual long Id { get; set; }
     public virtual string Name { get; set; }
 }
 
@@ -121,8 +122,9 @@ public class Child2Record : ChildRecord
     public virtual string Third { get; set; }
 }
 
-public class Record : Entity
+public class Record
 {
+    public virtual long Id { get; set; }
     public virtual string Name { get; set; }
     public virtual int Age { get; set; }
     public virtual string Location { get; set; }
@@ -136,8 +138,9 @@ public class BinaryRecordMap : ClassMap<BinaryRecord>
         Map(x => x.BinaryValue).Not.Nullable();
     }
 }
-public class BinaryRecord : Entity
+public class BinaryRecord
 {
+    public virtual long Id { get; set; }
     public virtual byte[] BinaryValue { get; set; }
 }
 
@@ -149,8 +152,11 @@ public class CachedRecordMap : ClassMap<CachedRecord>
         Id(x => x.Id, "id");
     }
 }
-public class CachedRecord : Entity
-{ }
+
+public class CachedRecord
+{
+    public virtual long Id { get; set; }
+}
 
 public class RecordFilter : FilterDefinition
 {
@@ -171,8 +177,9 @@ public sealed class RecordWithNullablePropertyMap : ClassMap<RecordWithNullableP
     }
 }
 
-public class RecordWithNullableProperty : Entity
+public class RecordWithNullableProperty
 {
+    public virtual long Id { get; set; }
     public virtual string Name { get; set; }
     public virtual int? Age { get; set; }
     public virtual string Location { get; set; }

--- a/src/FluentNHibernate.Testing/DomainModel/EntityEquality.cs
+++ b/src/FluentNHibernate.Testing/DomainModel/EntityEquality.cs
@@ -4,7 +4,7 @@ using NUnit.Framework;
 
 namespace FluentNHibernate.Testing.DomainModel;
 
-[TestFixture, Obsolete]
+[TestFixture, Obsolete("Testing obsolete FluentNHibernate.Data.Entity")]
 public class EntityEquality
 {
     [Test]

--- a/src/FluentNHibernate.Testing/DomainModel/EntityEquality.cs
+++ b/src/FluentNHibernate.Testing/DomainModel/EntityEquality.cs
@@ -1,9 +1,10 @@
+using System;
 using FluentNHibernate.Data;
 using NUnit.Framework;
 
 namespace FluentNHibernate.Testing.DomainModel;
 
-[TestFixture]
+[TestFixture, Obsolete]
 public class EntityEquality
 {
     [Test]
@@ -53,7 +54,7 @@ public class EntityEquality
     [Test]
     public void Subclassed_entities_should_equal_each_other_with_same_Id()
     {
-        var first = new TestSubEntity {Id = 99};
+        var first = new TestSubEntity { Id = 99 };
         var second = new TestSubEntity { Id = 99 };
 
         first.Equals(second).ShouldBeTrue();
@@ -77,18 +78,11 @@ public class EntityEquality
         first.Equals(second).ShouldBeFalse();
     }
 
-    public class ConcreteEntity : Entity
-    {}
+    public class ConcreteEntity : Entity;
 
-    public class TestSubEntity : ConcreteEntity
-    {
-    }
+    public class TestSubEntity : ConcreteEntity;
 
-    public class AnotherSubEntity : ConcreteEntity
-    {
-    }
+    public class AnotherSubEntity : ConcreteEntity;
 
-    public class DeepSubEntity : TestSubEntity
-    {
-    }
+    public class DeepSubEntity : TestSubEntity;
 }

--- a/src/FluentNHibernate.Testing/DomainModel/InverseOneToManyTester.cs
+++ b/src/FluentNHibernate.Testing/DomainModel/InverseOneToManyTester.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using FluentNHibernate.Mapping;
 using NUnit.Framework;
@@ -28,14 +29,14 @@ public class InverseOneToManyTester
     {
         var artists = new List<Artist>
         {
-            new Artist {Name = "Artist1"},
-            new Artist {Name = "Artist2"}
+            new Artist { Name = "Artist1" },
+            new Artist { Name = "Artist2" }
         };
 
         new PersistenceSpecification<Genre>(_source)
             .CheckProperty(g => g.Id, 1L)
             .CheckProperty(g => g.Name, "Genre")
-            .CheckComponentList(g => g.Artists, artists, (g, a) => g.AddArtist(a))
+            .CheckInverseList(g => g.Artists, artists, new FuncEqualityComparer<Artist>(a => a.Id), (genre, artist) => genre.AddArtist(artist))
             .VerifyTheMappings();
     }
 }
@@ -78,4 +79,10 @@ public class GenreMap : ClassMap<Genre>
             .Cascade.All()
             .Inverse();
     }
+}
+
+class FuncEqualityComparer<T>(Func<T, object> func) : EqualityComparer<T>
+{
+    public override bool Equals(T x, T y) => Equals(func(x), func(y));
+    public override int GetHashCode(T obj) => throw new NotSupportedException();
 }

--- a/src/FluentNHibernate.Testing/DomainModel/Music.cs
+++ b/src/FluentNHibernate.Testing/DomainModel/Music.cs
@@ -1,10 +1,10 @@
 ﻿using System.Collections.Generic;
-using FluentNHibernate.Data;
 
 namespace FluentNHibernate.Testing.DomainModel;
 
-public class Artist : Entity
+public class Artist
 {
+    public virtual long Id { get; set; }
     public virtual string Name { get; set; }
     public virtual ISet<Album> Albums { get; set; }
     public virtual Genre Genre { get; set; }
@@ -15,8 +15,9 @@ public class Artist : Entity
     }
 }
 
-public class Genre : Entity
+public class Genre
 {
+    public virtual long Id { get; set; }
     public virtual string Name { get; set; }
     public virtual IList<Artist> Artists { get; set; }
 

--- a/src/FluentNHibernate/Data/Entity.cs
+++ b/src/FluentNHibernate/Data/Entity.cs
@@ -3,6 +3,7 @@
 namespace FluentNHibernate.Data;
 
 [Serializable]
+[Obsolete("This base class is problematic as it does not consider transient entities and a requirement to have immutable GetHashCode()")]
 public abstract class Entity : IEquatable<Entity>
 {
     public virtual long Id { get; set; }

--- a/src/FluentNHibernate/Data/Entity.cs
+++ b/src/FluentNHibernate/Data/Entity.cs
@@ -3,7 +3,7 @@
 namespace FluentNHibernate.Data;
 
 [Serializable]
-[Obsolete("This base class is problematic as it does not consider transient entities and a requirement to have immutable GetHashCode()")]
+[Obsolete("Please do not use this class and implement your own as this base class is problematic because it does not consider transient entities and a requirement to have immutable GetHashCode().")]
 public abstract class Entity : IEquatable<Entity>
 {
     public virtual long Id { get; set; }


### PR DESCRIPTION
The `FluentNHibernate.Data.Entity` class is problematic because of the following:

* It does not consider transient entities (see #376)
* It does not uphold the requirement to have a stable `GetHashCode()` during the lifetime of the entity
* It probably does have a bug working with proxies as it checks for a concrete type.

Instead of using `FluentNHibernate.Data.Entity` please implement your own.

Closes #376