### PR TITLE
Allow specification of <sql-*> in subclasses

### DIFF
--- a/src/FluentNHibernate.Testing/DomainModel/Mapping/StoredProcedureTests.cs
+++ b/src/FluentNHibernate.Testing/DomainModel/Mapping/StoredProcedureTests.cs
@@ -91,7 +91,7 @@ public class StoredProcedureTests
     {
         var check = "Delete ABC";
         CreateMappingTester(x => x.SqlDeleteAll(check))
-            .Element("//subclass/sql-delete")
+            .Element("//subclass/sql-delete-all")
             .ValueEquals(check);
     }
 

--- a/src/FluentNHibernate.Testing/DomainModel/Mapping/StoredProcedureTests.cs
+++ b/src/FluentNHibernate.Testing/DomainModel/Mapping/StoredProcedureTests.cs
@@ -1,4 +1,6 @@
-﻿using NUnit.Framework;
+﻿using System;
+using FluentNHibernate.Mapping;
+using NUnit.Framework;
 
 namespace FluentNHibernate.Testing.DomainModel.Mapping;
 
@@ -55,5 +57,56 @@ public class StoredProcedureTests
             })
             .Element("class/sql-delete-all")
             .ValueEquals("Delete ABC");
+    }
+    
+    [Test]
+    public void Can_specify_sql_insert_for_subclass()
+    {
+        var check = "Insert ABC";
+        CreateMappingTester(x => x.SqlInsert(check))
+            .Element("//subclass/sql-insert")
+            .ValueEquals(check);
+    }
+    
+    [Test]
+    public void Can_specify_sql_update_for_subclass()
+    {
+        var check = "Update ABC";
+        CreateMappingTester(x => x.SqlUpdate(check))
+            .Element("//subclass/sql-update")
+            .ValueEquals(check);
+    }
+    
+    [Test]
+    public void Can_specify_sql_delete_for_subclass()
+    {
+        var check = "Delete ABC";
+        CreateMappingTester(x => x.SqlDelete(check))
+            .Element("//subclass/sql-delete")
+            .ValueEquals(check);
+    }
+    
+    [Test]
+    public void Can_specify_sql_delete_all_for_subclass()
+    {
+        var check = "Delete ABC";
+        CreateMappingTester(x => x.SqlDeleteAll(check))
+            .Element("//subclass/sql-delete")
+            .ValueEquals(check);
+    }
+
+    private MappingTester<MappedObject> CreateMappingTester(Action<SubclassMap<MappedObjectSubclass>> subclassMap)
+    {
+        return new MappingTester<MappedObject>()
+            .SubClassMapping<MappedObjectSubclass>(sc =>
+            {
+                sc.Map(x => x.SubclassProperty);
+                subclassMap.Invoke(sc);
+            })
+            .ForMapping(m =>
+            {
+                m.DiscriminateSubClassesOnColumn("test");
+                m.Id(x => x.Id);
+            });
     }
 }

--- a/src/FluentNHibernate/Mapping/SubclassMap.cs
+++ b/src/FluentNHibernate/Mapping/SubclassMap.cs
@@ -327,9 +327,11 @@ public class SubclassMap<T> : ClasslikeMapBase<T>, IIndeterminateSubclassMapping
                 case MappingProviderStore.ProviderType.Any:
                     mapping.AddAny(((IAnyMappingProvider)mappingProviderObj).GetAnyMapping());
                     break;
+                case MappingProviderStore.ProviderType.StoredProcedure:
+                    mapping.AddStoredProcedure(((IStoredProcedureMappingProvider)mappingProviderObj).GetStoredProcedureMapping());
+                    break;
                 case MappingProviderStore.ProviderType.Subclass:
                 case MappingProviderStore.ProviderType.Filter:
-                case MappingProviderStore.ProviderType.StoredProcedure:
                 case MappingProviderStore.ProviderType.Join:
                 case MappingProviderStore.ProviderType.Identity:
                 case MappingProviderStore.ProviderType.CompositeId:


### PR DESCRIPTION
Clean-up version of https://github.com/nhibernate/fluent-nhibernate/pull/727 concerning only `<sql-*>` mapping.

Fixes #41