### PR TITLE
Add ability to specify idbag (#415)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,15 +6,29 @@ on:
   pull_request:
 
 jobs:
-  build_and_test:
-    runs-on: ubuntu-latest
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, ubuntu-latest]
+
+    runs-on: ${{ matrix.os }}
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-      - name: Setup .NET
+      # Install both SDKs so tests can run where applicable
+      - name: Setup .NET 6
         uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "6.0.x"
+
+      - name: Setup .NET 8
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0.x"
 
       - name: Restore
         run: dotnet restore src/FluentNHibernate.sln
@@ -22,6 +36,12 @@ jobs:
       - name: Build
         run: dotnet build src/FluentNHibernate.sln -c Release --no-restore
 
-      - name: Test
-        run: dotnet test src/FluentNHibernate.sln -c Release --no-build
-  
+      # Windows: run net48 tests (works natively)
+      - name: Test (net48)
+        if: runner.os == 'Windows'
+        run: dotnet test src/FluentNHibernate.sln -c Release --no-build -f net48
+
+      # Linux: run net6 tests
+      - name: Test (net6.0)
+        if: runner.os != 'Windows'
+        run: dotnet test src/FluentNHibernate.sln -c Release --no-build -f net6.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [ "**" ]
+  pull_request:
+
+jobs:
+  build_and_test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+
+      - name: Restore
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build -c Release --no-restore
+
+      - name: Test
+        run: dotnet test -c Release --no-build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,11 @@ jobs:
         uses: actions/setup-dotnet@v4
 
       - name: Restore
-        run: dotnet restore
+        run: dotnet restore src/FluentNHibernate.sln
 
       - name: Build
-        run: dotnet build -c Release --no-restore
+        run: dotnet build src/FluentNHibernate.sln -c Release --no-restore
 
       - name: Test
-        run: dotnet test -c Release --no-build
+        run: dotnet test src/FluentNHibernate.sln -c Release --no-build
+  

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -1,0 +1,33 @@
+name: Publish NuGet
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build_pack_push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # important if you use GitVersion / tags
+
+      - name: Setup .NET (uses global.json if present)
+        uses: actions/setup-dotnet@v4
+
+      - name: Restore
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build -c Release --no-restore
+
+      - name: Test
+        run: dotnet test -c Release --no-build
+
+      - name: Pack
+        run: dotnet pack -c Release --no-build -o ./artifacts
+
+      - name: Push to NuGet.org
+        run: dotnet nuget push "./artifacts/*.nupkg" --api-key "${{ secrets.NUGET_API_KEY }}" --source "https://api.nuget.org/v3/index.json" --skip-duplicate

--- a/src/FluentNHibernate.Testing/DomainModel/Mapping/ManyToManyTester.cs
+++ b/src/FluentNHibernate.Testing/DomainModel/Mapping/ManyToManyTester.cs
@@ -351,7 +351,7 @@ public class ManyToManyTester
     [Test]
     public void CanSpecifyIdBagWithLength()
     {
-        var x = new MappingTester<ManyToManyTarget>()
+        new MappingTester<ManyToManyTarget>()
             .ForMapping(m => m.HasManyToMany(x => x.MapOfChildren)
                 .AsIdBag<string>(x => x.Column("Id").Length(10)))
             .Element("class/idbag/collection-id").Exists()
@@ -365,7 +365,7 @@ public class ManyToManyTester
     [Test]
     public void CanSpecifyIdBagWithNonGenericType()
     {
-        var x = new MappingTester<ManyToManyTarget>()
+        new MappingTester<ManyToManyTarget>()
             .ForMapping(m => m.HasManyToMany(x => x.MapOfChildren)
                 .AsIdBag(typeof(string), x => x.Column("Id").Length(10)))
             .Element("class/idbag/collection-id").Exists()
@@ -379,7 +379,7 @@ public class ManyToManyTester
     [Test]
     public void CanSpecifyIdBagWithGenerator()
     {
-        var x = new MappingTester<ManyToManyTarget>()
+        new MappingTester<ManyToManyTarget>()
             .ForMapping(m => m.HasManyToMany(x => x.MapOfChildren)
                 .AsIdBag(typeof(int), x => x.GeneratedBy.Identity()))
             .Element("class/idbag/collection-id").Exists()

--- a/src/FluentNHibernate.Testing/DomainModel/Mapping/ManyToManyTester.cs
+++ b/src/FluentNHibernate.Testing/DomainModel/Mapping/ManyToManyTester.cs
@@ -388,4 +388,15 @@ public class ManyToManyTester
             .Element("class/idbag/collection-id/generator").Exists()
                 .HasAttribute("class", "identity");
     }
+    
+    [Test]
+    public void CanSpecifyIdBagWithDefaultIdType()
+    {
+        new MappingTester<ManyToManyTarget>()
+            .ForMapping(m => m.HasManyToMany(x => x.MapOfChildren)
+                .AsIdBag(x => x.Column("Id")))
+            .Element("class/idbag/collection-id").Exists()
+            .HasAttribute("column", "Id")
+            .HasAttribute("type",  typeof(int).AssemblyQualifiedName);
+    }
 }

--- a/src/FluentNHibernate.Testing/DomainModel/Mapping/ManyToManyTester.cs
+++ b/src/FluentNHibernate.Testing/DomainModel/Mapping/ManyToManyTester.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using NUnit.Framework;
@@ -332,5 +333,59 @@ public class ManyToManyTester
                 .ChildKeyColumns.Add("ID2"))
             .Element("class/bag/many-to-many/column[@name='ID1']").Exists()
             .Element("class/bag/many-to-many/column[@name='ID2']").Exists();
+    }
+    
+    [Test]
+    public void CanSpecifyIdBag()
+    {
+        new MappingTester<ManyToManyTarget>()
+            .ForMapping(m => m.HasManyToMany(x => x.MapOfChildren)
+                .AsIdBag<int>(x => x.Column("Id").GeneratedBy.Identity()))
+            .Element("class/idbag/collection-id").Exists()
+                .HasAttribute("column", "Id")
+                .HasAttribute("type",  typeof(int).AssemblyQualifiedName)
+            .Element("class/idbag/collection-id/generator").Exists()
+                .HasAttribute("class", "identity");
+    }
+    
+    [Test]
+    public void CanSpecifyIdBagWithLength()
+    {
+        var x = new MappingTester<ManyToManyTarget>()
+            .ForMapping(m => m.HasManyToMany(x => x.MapOfChildren)
+                .AsIdBag<string>(x => x.Column("Id").Length(10)))
+            .Element("class/idbag/collection-id").Exists()
+                .HasAttribute("column", "Id")
+                .HasAttribute("type",  typeof(string).AssemblyQualifiedName)
+                .HasAttribute("length", "10")
+            .Element("class/idbag/collection-id/generator").Exists()
+                .HasAttribute("class", "assigned");
+    }
+    
+    [Test]
+    public void CanSpecifyIdBagWithNonGenericType()
+    {
+        var x = new MappingTester<ManyToManyTarget>()
+            .ForMapping(m => m.HasManyToMany(x => x.MapOfChildren)
+                .AsIdBag(typeof(string), x => x.Column("Id").Length(10)))
+            .Element("class/idbag/collection-id").Exists()
+                .HasAttribute("column", "Id")
+                .HasAttribute("type",  typeof(string).AssemblyQualifiedName)
+                .HasAttribute("length", "10")
+            .Element("class/idbag/collection-id/generator").Exists()
+                .HasAttribute("class", "assigned");
+    }
+    
+    [Test]
+    public void CanSpecifyIdBagWithGenerator()
+    {
+        var x = new MappingTester<ManyToManyTarget>()
+            .ForMapping(m => m.HasManyToMany(x => x.MapOfChildren)
+                .AsIdBag(typeof(int), x => x.GeneratedBy.Identity()))
+            .Element("class/idbag/collection-id").Exists()
+                .HasAttribute("column", "Id")
+                .HasAttribute("type",  typeof(int).AssemblyQualifiedName)
+            .Element("class/idbag/collection-id/generator").Exists()
+                .HasAttribute("class", "identity");
     }
 }

--- a/src/FluentNHibernate.Testing/DomainModel/Mapping/ManyToManyTester.cs
+++ b/src/FluentNHibernate.Testing/DomainModel/Mapping/ManyToManyTester.cs
@@ -339,22 +339,21 @@ public class ManyToManyTester
     public void CanSpecifyIdBag()
     {
         new MappingTester<ManyToManyTarget>()
-            .ForMapping(m => m.HasManyToMany(x => x.MapOfChildren)
-                .AsIdBag<int>(x => x.Column("Id").GeneratedBy.Identity()))
-            .Element("class/idbag/collection-id").Exists()
+            .ForMapping(m => m.HasManyToMany(x => x.BagOfChildren)
+                .AsIdBag<int>(x => x.Column("Id")))
+            .Element("class/idbag/collection-id").Exists().ShouldBeInParentAtPosition(0)
                 .HasAttribute("column", "Id")
                 .HasAttribute("type",  typeof(int).AssemblyQualifiedName)
-            .Element("class/idbag/collection-id/generator").Exists()
-                .HasAttribute("class", "identity");
+            .Element("class/idbag/many-to-many").Exists();
     }
     
     [Test]
     public void CanSpecifyIdBagWithLength()
     {
         new MappingTester<ManyToManyTarget>()
-            .ForMapping(m => m.HasManyToMany(x => x.MapOfChildren)
+            .ForMapping(m => m.HasManyToMany(x => x.BagOfChildren)
                 .AsIdBag<string>(x => x.Column("Id").Length(10)))
-            .Element("class/idbag/collection-id").Exists()
+            .Element("class/idbag/collection-id").Exists().ShouldBeInParentAtPosition(0)
                 .HasAttribute("column", "Id")
                 .HasAttribute("type",  typeof(string).AssemblyQualifiedName)
                 .HasAttribute("length", "10")
@@ -366,25 +365,19 @@ public class ManyToManyTester
     public void CanSpecifyIdBagWithNonGenericType()
     {
         new MappingTester<ManyToManyTarget>()
-            .ForMapping(m => m.HasManyToMany(x => x.MapOfChildren)
-                .AsIdBag(typeof(string), x => x.Column("Id").Length(10)))
-            .Element("class/idbag/collection-id").Exists()
-                .HasAttribute("column", "Id")
-                .HasAttribute("type",  typeof(string).AssemblyQualifiedName)
-                .HasAttribute("length", "10")
-            .Element("class/idbag/collection-id/generator").Exists()
-                .HasAttribute("class", "assigned");
+            .ForMapping(m => m.HasManyToMany(x => x.BagOfChildren)
+                .AsIdBag(typeof(string)))
+            .Element("class/idbag/collection-id").Exists().ShouldBeInParentAtPosition(0)
+                .HasAttribute("type", typeof(string).AssemblyQualifiedName);
     }
     
     [Test]
     public void CanSpecifyIdBagWithGenerator()
     {
         new MappingTester<ManyToManyTarget>()
-            .ForMapping(m => m.HasManyToMany(x => x.MapOfChildren)
+            .ForMapping(m => m.HasManyToMany(x => x.BagOfChildren)
                 .AsIdBag(typeof(int), x => x.GeneratedBy.Identity()))
-            .Element("class/idbag/collection-id").Exists()
-                .HasAttribute("column", "Id")
-                .HasAttribute("type",  typeof(int).AssemblyQualifiedName)
+            .Element("class/idbag/collection-id").Exists().ShouldBeInParentAtPosition(0)
             .Element("class/idbag/collection-id/generator").Exists()
                 .HasAttribute("class", "identity");
     }
@@ -393,10 +386,36 @@ public class ManyToManyTester
     public void CanSpecifyIdBagWithDefaultIdType()
     {
         new MappingTester<ManyToManyTarget>()
-            .ForMapping(m => m.HasManyToMany(x => x.MapOfChildren)
-                .AsIdBag(x => x.Column("Id")))
-            .Element("class/idbag/collection-id").Exists()
-            .HasAttribute("column", "Id")
-            .HasAttribute("type",  typeof(int).AssemblyQualifiedName);
+            .ForMapping(m => m.HasManyToMany(x => x.BagOfChildren)
+                .AsIdBag())
+            .Element("class/idbag/collection-id").Exists().ShouldBeInParentAtPosition(0)
+                .HasAttribute("type",  typeof(int).AssemblyQualifiedName);
+    }
+    
+    [Test]
+    public void CanSpecifyIdBagWithCompositeElement()
+    {
+        new MappingTester<ManyToManyTarget>()
+            .ForMapping(m => m.HasManyToMany(x => x.BagOfChildren)
+                .Component(c =>
+                {
+                    c.Map(x => x.Name);
+                    c.Map(x => x.Active);
+                })
+                .AsIdBag())
+            .Element("class/idbag/collection-id").Exists().ShouldBeInParentAtPosition(0)
+            .Element("class/idbag/composite-element").Exists()
+            .Element("class/idbag/composite-element/property[@name='Name']").Exists();
+    }
+    
+    [Test]
+    public void CanSpecifyIdBagWithElement()
+    {
+        var x = new MappingTester<ManyToManyTarget>()
+            .ForMapping(m => m.HasManyToMany(x => x.ListOfSimpleChildren)
+                .Element("Name")
+                .AsIdBag());
+        x.Element("class/idbag/collection-id").Exists().ShouldBeInParentAtPosition(0)
+            .Element("class/idbag/element").Exists();
     }
 }

--- a/src/FluentNHibernate.Testing/MappingModel/Output/XmlCacheWriterTester.cs
+++ b/src/FluentNHibernate.Testing/MappingModel/Output/XmlCacheWriterTester.cs
@@ -29,4 +29,15 @@ public class XmlCacheWriterTester
 
         testHelper.VerifyAll(writer);
     }
+    /*
+    [Test]
+    public void ShouldWriteIncludeAttribute()
+    {
+        writer = new XmlCacheWriter();
+        var testHelper = new XmlWriterTestHelper<CacheMapping>();
+        testHelper.Check(x => x.Include, "include").MapsToAttribute("include");
+
+        testHelper.VerifyAll(writer);
+    }
+    */
 }

--- a/src/FluentNHibernate/Automapping/Steps/IdentityStep.cs
+++ b/src/FluentNHibernate/Automapping/Steps/IdentityStep.cs
@@ -9,8 +9,6 @@ namespace FluentNHibernate.Automapping.Steps;
 
 public class IdentityStep(IAutomappingConfiguration cfg) : IAutomappingStep
 {
-    readonly List<Type> identityCompatibleTypes = new List<Type> { typeof(long), typeof(int), typeof(short), typeof(byte) };
-
     public bool ShouldMap(Member member)
     {
         return cfg.IsId(member);
@@ -52,15 +50,7 @@ public class IdentityStep(IAutomappingConfiguration cfg) : IAutomappingStep
     GeneratorMapping GetDefaultGenerator(Member property)
     {
         var generatorMapping = new GeneratorMapping();
-        var defaultGenerator = new GeneratorBuilder(generatorMapping, property.PropertyType, Layer.Defaults);
-
-        if (property.PropertyType == typeof(Guid))
-            defaultGenerator.GuidComb();
-        else if (identityCompatibleTypes.Contains(property.PropertyType))
-            defaultGenerator.Identity();
-        else
-            defaultGenerator.Assigned();
-
+        new GeneratorBuilder(generatorMapping, property.PropertyType, Layer.Defaults).SetDefault();
         return generatorMapping;
     }
 }

--- a/src/FluentNHibernate/FluentNHibernate.csproj
+++ b/src/FluentNHibernate/FluentNHibernate.csproj
@@ -14,6 +14,16 @@
     <RuntimeFrameworkVersion>2.0.9</RuntimeFrameworkVersion>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <PackageId>FluentNHibernate.Toofy</PackageId>
+    <AssemblyName>FluentNHibernate.Toofy</AssemblyName>
+    <RootNamespace>FluentNHibernate</RootNamespace>
+    <Authors>Impartner</Authors>
+    <RepositoryUrl>https://github.com/jeff-hagen/fluent-nhibernate</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/jeff-hagen/fluent-nhibernate</PackageProjectUrl>
+  </PropertyGroup>
+
+
   <ItemGroup>
     <PackageReference Include="NHibernate" Version="5.4.9" />
   </ItemGroup>

--- a/src/FluentNHibernate/Mapping/CollectionIdPart.cs
+++ b/src/FluentNHibernate/Mapping/CollectionIdPart.cs
@@ -17,7 +17,7 @@ public class CollectionIdPart : ICollectionIdMappingProvider
     /// <example>
     /// .AsIdBag&lt;int&gt;(x => x.Column("Id").GeneratedBy.Identity())
     /// </example>
-    public IdentityGenerationStrategyBuilder<CollectionIdPart> GeneratedBy { get; }F
+    public IdentityGenerationStrategyBuilder<CollectionIdPart> GeneratedBy { get; }
 
     public CollectionIdPart(Type entityType, Type idColumnType)
     {

--- a/src/FluentNHibernate/Mapping/CollectionIdPart.cs
+++ b/src/FluentNHibernate/Mapping/CollectionIdPart.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using FluentNHibernate.Mapping.Providers;
+using FluentNHibernate.MappingModel;
+using FluentNHibernate.MappingModel.Collections;
+using FluentNHibernate.MappingModel.Identity;
+
+namespace FluentNHibernate.Mapping;
+
+public class CollectionIdPart : ICollectionIdMappingProvider
+{
+    readonly Type entity;
+    readonly AttributeStore attributes = new AttributeStore();
+    
+    /// <summary>
+    /// Specify the generator
+    /// </summary>
+    /// <example>
+    /// .AsIdBag&lt;int&gt;(x => x.Column("Id").GeneratedBy.Identity())
+    /// </example>
+    public IdentityGenerationStrategyBuilder<CollectionIdPart> GeneratedBy { get; }
+
+    public CollectionIdPart(Type entityType, Type idColumnType)
+    {
+        attributes.Set("Type", Layer.UserSupplied, new TypeReference(idColumnType));
+        entity = entityType;
+        GeneratedBy = new IdentityGenerationStrategyBuilder<CollectionIdPart>(this, idColumnType, entityType);
+        SetDefaultGenerator(idColumnType);
+    }
+    
+    /// <summary>
+    /// Specifies the id column length
+    /// </summary>
+    /// <param name="length">Column length</param>
+    public CollectionIdPart Length(int length)
+    {
+        attributes.Set("Length", Layer.UserSupplied, length);
+        return this;
+    }
+    
+    /// <summary>
+    /// Specifies the column name for the collection id.
+    /// </summary>
+    /// <param name="idColumnName">Column name</param>
+    public CollectionIdPart Column(string idColumnName)
+    {
+        attributes.Set("Column", Layer.UserSupplied, idColumnName);
+        return this;
+    }
+    
+    void SetDefaultGenerator(Type idColumnType)
+    {
+        var generatorMapping = new GeneratorMapping();
+        new GeneratorBuilder(generatorMapping, idColumnType, Layer.UserSupplied).SetDefault();
+        attributes.Set("Generator", Layer.Defaults, generatorMapping);
+    }
+
+    CollectionIdMapping ICollectionIdMappingProvider.GetCollectionIdMapping()
+    {
+        var mapping = new CollectionIdMapping(attributes.Clone());
+
+        mapping.ContainingEntityType = entity;
+        mapping.Set(x => x.Column, Layer.Defaults, "Id");
+        if (GeneratedBy.IsDirty)
+            mapping.Set(x => x.Generator, Layer.UserSupplied, GeneratedBy.GetGeneratorMapping());
+        
+        return mapping;
+    }
+}

--- a/src/FluentNHibernate/Mapping/CollectionIdPart.cs
+++ b/src/FluentNHibernate/Mapping/CollectionIdPart.cs
@@ -9,7 +9,7 @@ namespace FluentNHibernate.Mapping;
 public class CollectionIdPart : ICollectionIdMappingProvider
 {
     readonly Type entity;
-    readonly AttributeStore attributes = new AttributeStore();
+    readonly AttributeStore attributes = new();
     
     /// <summary>
     /// Specify the generator
@@ -17,7 +17,7 @@ public class CollectionIdPart : ICollectionIdMappingProvider
     /// <example>
     /// .AsIdBag&lt;int&gt;(x => x.Column("Id").GeneratedBy.Identity())
     /// </example>
-    public IdentityGenerationStrategyBuilder<CollectionIdPart> GeneratedBy { get; }
+    public IdentityGenerationStrategyBuilder<CollectionIdPart> GeneratedBy { get; }F
 
     public CollectionIdPart(Type entityType, Type idColumnType)
     {
@@ -56,9 +56,11 @@ public class CollectionIdPart : ICollectionIdMappingProvider
 
     CollectionIdMapping ICollectionIdMappingProvider.GetCollectionIdMapping()
     {
-        var mapping = new CollectionIdMapping(attributes.Clone());
-
-        mapping.ContainingEntityType = entity;
+        var mapping = new CollectionIdMapping(attributes.Clone())
+        {
+            ContainingEntityType = entity
+        };
+        
         mapping.Set(x => x.Column, Layer.Defaults, "Id");
         if (GeneratedBy.IsDirty)
             mapping.Set(x => x.Generator, Layer.UserSupplied, GeneratedBy.GetGeneratorMapping());

--- a/src/FluentNHibernate/Mapping/GeneratorBuilder.cs
+++ b/src/FluentNHibernate/Mapping/GeneratorBuilder.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using FluentNHibernate.MappingModel.Identity;
 using NHibernate.Id;
 
@@ -6,6 +7,8 @@ namespace FluentNHibernate.Mapping;
 
 class GeneratorBuilder(GeneratorMapping mapping, Type identityType, int layer)
 {
+    readonly HashSet<Type> identityCompatibleTypes = new HashSet<Type>{ typeof(long), typeof(int), typeof(short), typeof(byte) };
+    
     void SetGenerator(string generator)
     {
         mapping.Set(x => x.Class, layer, generator);
@@ -29,6 +32,16 @@ class GeneratorBuilder(GeneratorMapping mapping, Type identityType, int layer)
     void EnsureStringIdentityType()
     {
         if (identityType != typeof(string)) throw new InvalidOperationException("Identity type must be string");
+    }
+
+    internal void SetDefault()
+    {
+        if (identityType == typeof(Guid))
+            GuidComb();
+        else if (identityCompatibleTypes.Contains(identityType))
+            Identity();
+        else
+            Assigned();
     }
 
     static bool IsIntegralType(Type t)

--- a/src/FluentNHibernate/Mapping/IdentityPart.cs
+++ b/src/FluentNHibernate/Mapping/IdentityPart.cs
@@ -250,15 +250,7 @@ public class IdentityPart : IIdentityMappingProvider
     void SetDefaultGenerator()
     {
         var generatorMapping = new GeneratorMapping();
-        var defaultGenerator = new GeneratorBuilder(generatorMapping, identityType, Layer.UserSupplied);
-
-        if (identityType == typeof(Guid))
-            defaultGenerator.GuidComb();
-        else if (identityType == typeof(int) || identityType == typeof(long))
-            defaultGenerator.Identity();
-        else
-            defaultGenerator.Assigned();
-
+        new GeneratorBuilder(generatorMapping, identityType, Layer.UserSupplied).SetDefault();
         attributes.Set("Generator", Layer.Defaults, generatorMapping);
     }
 

--- a/src/FluentNHibernate/Mapping/Providers/ICollectionIdMappingProvider.cs
+++ b/src/FluentNHibernate/Mapping/Providers/ICollectionIdMappingProvider.cs
@@ -1,0 +1,8 @@
+using FluentNHibernate.MappingModel.Collections;
+
+namespace FluentNHibernate.Mapping.Providers;
+
+public interface ICollectionIdMappingProvider
+{
+    CollectionIdMapping GetCollectionIdMapping();
+}

--- a/src/FluentNHibernate/Mapping/ToManyBase.cs
+++ b/src/FluentNHibernate/Mapping/ToManyBase.cs
@@ -16,13 +16,12 @@ public abstract class ToManyBase<T, TChild> : ICollectionMappingProvider
     protected ElementPart elementPart;
     protected ICompositeElementMappingProvider componentMapping;
     protected bool nextBool = true;
+    protected Func<AttributeStore, CollectionMapping> collectionBuilder;
 
     protected readonly AttributeStore collectionAttributes = new AttributeStore();
     protected readonly KeyMapping keyMapping = new KeyMapping();
     protected readonly AttributeStore relationshipAttributes = new AttributeStore();
-    Func<AttributeStore, CollectionMapping> collectionBuilder;
     IndexMapping indexMapping;
-    CollectionIdMapping collectionIdMapping;
     protected Member member;
     readonly List<IFilterMappingProvider> filters = [];
 
@@ -152,26 +151,6 @@ public abstract class ToManyBase<T, TChild> : ICollectionMappingProvider
     public T AsBag()
     {
         collectionBuilder = attrs => CollectionMapping.Bag(attrs);
-        return (T)this;
-    }
-
-    /// <summary>
-    /// Use an idbag collection
-    /// </summary>
-    public T AsIdBag<TIdType>(Action<CollectionIdPart> customId = null)
-    {
-        return AsIdBag(typeof(TIdType), customId);
-    }
-    
-    /// <summary>
-    /// Use an idbag collection
-    /// </summary>
-    public T AsIdBag(Type idColType, Action<CollectionIdPart> customId = null)
-    {
-        collectionBuilder = attrs => CollectionMapping.IdBag(attrs);
-        var builder = new CollectionIdPart(typeof(T), idColType);
-        customId?.Invoke(builder);
-        collectionIdMapping = ((ICollectionIdMappingProvider)builder).GetCollectionIdMapping();
         return (T)this;
     }
 
@@ -746,9 +725,7 @@ public abstract class ToManyBase<T, TChild> : ICollectionMappingProvider
         // HACK: Index only on list and map - shouldn't have to do this!
         if (mapping.Collection == Collection.Array || mapping.Collection == Collection.List || mapping.Collection == Collection.Map)
             mapping.Set(x => x.Index, Layer.Defaults, indexMapping);
-        else if (mapping.Collection == Collection.IdBag)
-            mapping.Set(x => x.CollectionId, Layer.Defaults, collectionIdMapping);
-
+        
         if (elementPart is not null)
         {
             mapping.Set(x => x.Element, Layer.Defaults, ((IElementMappingProvider)elementPart).GetElementMapping());

--- a/src/FluentNHibernate/MappingModel/Collections/Collection.cs
+++ b/src/FluentNHibernate/MappingModel/Collections/Collection.cs
@@ -6,5 +6,6 @@ public enum Collection
     Bag,
     Map,
     List,
-    Set
+    Set,
+    IdBag
 }

--- a/src/FluentNHibernate/MappingModel/Collections/CollectionIdMapping.cs
+++ b/src/FluentNHibernate/MappingModel/Collections/CollectionIdMapping.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Linq.Expressions;
+using FluentNHibernate.MappingModel.Identity;
+using FluentNHibernate.Utils;
+using FluentNHibernate.Visitors;
+
+namespace FluentNHibernate.MappingModel.Collections;
+
+[Serializable]
+public class CollectionIdMapping(AttributeStore attributes) : MappingBase, IEquatable<CollectionIdMapping>
+{
+    readonly AttributeStore attributes = attributes;
+
+    public override void AcceptVisitor(IMappingModelVisitor visitor)
+    {
+        visitor.ProcessCollectionId(this);
+        if (Generator is not null)
+            visitor.Visit(Generator);
+    }
+    
+    public GeneratorMapping Generator => attributes.GetOrDefault<GeneratorMapping>();
+    
+    public string Column => attributes.GetOrDefault<string>();
+    
+    public int Length => attributes.GetOrDefault<int>();
+    
+    public TypeReference Type => attributes.GetOrDefault<TypeReference>();
+    
+    public Type ContainingEntityType { get; set; }
+    
+    public bool Equals(CollectionIdMapping other)
+    {
+        if (ReferenceEquals(null, other)) return false;
+        if (ReferenceEquals(this, other)) return true;
+        return Equals(other.attributes, attributes) &&
+               other.ContainingEntityType == ContainingEntityType;
+    }
+
+    public override bool Equals(object obj)
+    {
+        if (ReferenceEquals(null, obj)) return false;
+        if (ReferenceEquals(this, obj)) return true;
+        if (obj.GetType() != typeof(CollectionIdMapping)) return false;
+        return Equals((CollectionIdMapping)obj);
+    }
+
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            int result = (attributes is not null ? attributes.GetHashCode() : 0);
+            result = (result * 397) ^ (ContainingEntityType is not null ? ContainingEntityType.GetHashCode() : 0);
+            return result;
+        }
+    }
+    
+    public void Set<T>(Expression<Func<CollectionIdMapping, T>> expression, int layer, T value)
+    {
+        Set(expression.ToMember().Name, layer, value);
+    }
+
+    protected override void Set(string attribute, int layer, object value)
+    {
+        attributes.Set(attribute, layer, value);
+    }
+
+    public override bool IsSpecified(string attribute)
+    {
+        return attributes.IsSpecified(attribute);
+    }
+}

--- a/src/FluentNHibernate/MappingModel/Collections/CollectionIdMapping.cs
+++ b/src/FluentNHibernate/MappingModel/Collections/CollectionIdMapping.cs
@@ -7,7 +7,7 @@ using FluentNHibernate.Visitors;
 namespace FluentNHibernate.MappingModel.Collections;
 
 [Serializable]
-public class CollectionIdMapping(AttributeStore attributes) : MappingBase, IEquatable<CollectionIdMapping>
+public sealed class CollectionIdMapping(AttributeStore attributes) : MappingBase, IEquatable<CollectionIdMapping>
 {
     readonly AttributeStore attributes = attributes;
 

--- a/src/FluentNHibernate/MappingModel/Collections/CollectionIdMapping.cs
+++ b/src/FluentNHibernate/MappingModel/Collections/CollectionIdMapping.cs
@@ -7,7 +7,7 @@ using FluentNHibernate.Visitors;
 namespace FluentNHibernate.MappingModel.Collections;
 
 [Serializable]
-public sealed class CollectionIdMapping(AttributeStore attributes) : MappingBase, IEquatable<CollectionIdMapping>
+public class CollectionIdMapping(AttributeStore attributes) : MappingBase, IEquatable<CollectionIdMapping>
 {
     readonly AttributeStore attributes = attributes;
 

--- a/src/FluentNHibernate/MappingModel/Collections/CollectionMapping.cs
+++ b/src/FluentNHibernate/MappingModel/Collections/CollectionMapping.cs
@@ -32,6 +32,9 @@ public class CollectionMapping : MappingBase, IRelationship, IEquatable<Collecti
     {
         visitor.ProcessCollection(this);
 
+        if (CollectionId is not null && Collection == Collection.IdBag)
+            visitor.Visit(CollectionId);
+        
         if (Key is not null)
             visitor.Visit(Key);
 
@@ -109,6 +112,8 @@ public class CollectionMapping : MappingBase, IRelationship, IEquatable<Collecti
     public string Sort => attributes.GetOrDefault<string>();
 
     public IIndexMapping Index => attributes.GetOrDefault<IIndexMapping>();
+    
+    public CollectionIdMapping CollectionId => attributes.GetOrDefault<CollectionIdMapping>();
 
     public bool Equals(CollectionMapping other)
     {
@@ -173,6 +178,11 @@ public class CollectionMapping : MappingBase, IRelationship, IEquatable<Collecti
     public static CollectionMapping Bag(AttributeStore underlyingStore)
     {
         return For(Collection.Bag, underlyingStore);
+    }
+    
+    public static CollectionMapping IdBag(AttributeStore underlyingStore)
+    {
+        return For(Collection.IdBag, underlyingStore);
     }
 
     public static CollectionMapping List()

--- a/src/FluentNHibernate/MappingModel/Collections/CollectionMapping.cs
+++ b/src/FluentNHibernate/MappingModel/Collections/CollectionMapping.cs
@@ -7,7 +7,7 @@ using FluentNHibernate.Visitors;
 namespace FluentNHibernate.MappingModel.Collections;
 
 [Serializable]
-public sealed class CollectionMapping : MappingBase, IRelationship, IEquatable<CollectionMapping>
+public class CollectionMapping : MappingBase, IRelationship, IEquatable<CollectionMapping>
 {
     readonly AttributeStore attributes;
     readonly List<FilterMapping> filters = [];

--- a/src/FluentNHibernate/MappingModel/Collections/CollectionMapping.cs
+++ b/src/FluentNHibernate/MappingModel/Collections/CollectionMapping.cs
@@ -7,7 +7,7 @@ using FluentNHibernate.Visitors;
 namespace FluentNHibernate.MappingModel.Collections;
 
 [Serializable]
-public class CollectionMapping : MappingBase, IRelationship, IEquatable<CollectionMapping>
+public sealed class CollectionMapping : MappingBase, IRelationship, IEquatable<CollectionMapping>
 {
     readonly AttributeStore attributes;
     readonly List<FilterMapping> filters = [];

--- a/src/FluentNHibernate/MappingModel/Output/CollectionAttributeWriter.cs
+++ b/src/FluentNHibernate/MappingModel/Output/CollectionAttributeWriter.cs
@@ -7,6 +7,7 @@ namespace FluentNHibernate.MappingModel.Output;
 
 public abstract class BaseXmlCollectionWriter(IXmlWriterServiceLocator serviceLocator) : NullMappingModelVisitor
 {
+    protected readonly IXmlWriterServiceLocator serviceLocator = serviceLocator;
     protected XmlDocument document;
 
     public override void Visit(KeyMapping mapping)

--- a/src/FluentNHibernate/MappingModel/Output/XmlArrayWriter.cs
+++ b/src/FluentNHibernate/MappingModel/Output/XmlArrayWriter.cs
@@ -7,8 +7,6 @@ namespace FluentNHibernate.MappingModel.Output;
 public class XmlArrayWriter(IXmlWriterServiceLocator serviceLocator)
     : BaseXmlCollectionWriter(serviceLocator), IXmlWriter<CollectionMapping>
 {
-    readonly IXmlWriterServiceLocator serviceLocator = serviceLocator;
-
     public XmlDocument Write(CollectionMapping mappingModel)
     {
         document = null;

--- a/src/FluentNHibernate/MappingModel/Output/XmlCollectionIdWriter.cs
+++ b/src/FluentNHibernate/MappingModel/Output/XmlCollectionIdWriter.cs
@@ -1,0 +1,43 @@
+using System.Xml;
+using FluentNHibernate.MappingModel.Collections;
+using FluentNHibernate.MappingModel.Identity;
+using FluentNHibernate.Utils;
+using FluentNHibernate.Visitors;
+
+namespace FluentNHibernate.MappingModel.Output;
+
+public class XmlCollectionIdWriter(IXmlWriterServiceLocator serviceLocator) : NullMappingModelVisitor, IXmlWriter<CollectionIdMapping>
+{
+    XmlDocument document;
+
+    public XmlDocument Write(CollectionIdMapping mappingModel)
+    {
+        document = null;
+        mappingModel.AcceptVisitor(this);
+        return document;
+    }
+
+    public override void ProcessCollectionId(CollectionIdMapping mapping)
+    {
+        document = new XmlDocument();
+
+        var element = document.AddElement("collection-id");
+
+        if (mapping.IsSpecified("Column"))
+            element.WithAtt("column", mapping.Column);
+
+        if (mapping.IsSpecified("Type"))
+            element.WithAtt("type", mapping.Type);
+
+        if (mapping.IsSpecified("Length"))
+            element.WithAtt("length", mapping.Length);
+    }
+
+    public override void Visit(GeneratorMapping mapping)
+    {
+        var writer = serviceLocator.GetWriter<GeneratorMapping>();
+        var generatorXml = writer.Write(mapping);
+
+        document.ImportAndAppendChild(generatorXml);
+    }
+}

--- a/src/FluentNHibernate/MappingModel/Output/XmlCollectionWriter.cs
+++ b/src/FluentNHibernate/MappingModel/Output/XmlCollectionWriter.cs
@@ -22,28 +22,16 @@ public class XmlCollectionWriter(IXmlWriterServiceLocator serviceLocator)
 
     public override void ProcessCollection(CollectionMapping mapping)
     {
-        IXmlWriter<CollectionMapping> writer = null;
-
-        switch (mapping.Collection)
+        IXmlWriter<CollectionMapping> writer = mapping.Collection switch
         {
-            case Collection.Array:
-                writer = new XmlArrayWriter(serviceLocator);
-                break;
-            case Collection.Bag:
-                writer = new XmlBagWriter(serviceLocator);
-                break;
-            case Collection.List:
-                writer = new XmlListWriter(serviceLocator);
-                break;
-            case Collection.Map:
-                writer = new XmlMapWriter(serviceLocator);
-                break;
-            case Collection.Set:
-                writer = new XmlSetWriter(serviceLocator);
-                break;
-            default:
-                throw new InvalidOperationException("Unrecognised collection type " + mapping.Collection);
-        }
+            Collection.Array => new XmlArrayWriter(serviceLocator),
+            Collection.Bag => new XmlBagWriter(serviceLocator),
+            Collection.List => new XmlListWriter(serviceLocator),
+            Collection.Map => new XmlMapWriter(serviceLocator),
+            Collection.Set => new XmlSetWriter(serviceLocator),
+            Collection.IdBag => new XmlIdBagWriter(serviceLocator),
+            _ => throw new InvalidOperationException("Unrecognised collection type " + mapping.Collection)
+        };
 
         document = writer.Write(mapping);
     }

--- a/src/FluentNHibernate/MappingModel/Output/XmlIdBagWriter.cs
+++ b/src/FluentNHibernate/MappingModel/Output/XmlIdBagWriter.cs
@@ -7,8 +7,6 @@ namespace FluentNHibernate.MappingModel.Output;
 
 public class XmlIdBagWriter(IXmlWriterServiceLocator serviceLocator) : BaseXmlCollectionWriter(serviceLocator), IXmlWriter<CollectionMapping>
 {
-    readonly IXmlWriterServiceLocator _serviceLocator = serviceLocator;
-
     public XmlDocument Write(CollectionMapping mappingModel)
     {
         document = null;
@@ -25,14 +23,14 @@ public class XmlIdBagWriter(IXmlWriterServiceLocator serviceLocator) : BaseXmlCo
     
     public override void Visit(CollectionIdMapping mapping)
     {
-        var writer = _serviceLocator.GetWriter<CollectionIdMapping>();
+        var writer = serviceLocator.GetWriter<CollectionIdMapping>();
         var xml = writer.Write(mapping);
         document.ImportAndAppendChild(xml);
     }
     
     public override void Visit(GeneratorMapping mapping)
     {
-        var writer = _serviceLocator.GetWriter<GeneratorMapping>();
+        var writer = serviceLocator.GetWriter<GeneratorMapping>();
         var generatorXml = writer.Write(mapping);
         document.ImportAndAppendChild(generatorXml);
     }

--- a/src/FluentNHibernate/MappingModel/Output/XmlIdBagWriter.cs
+++ b/src/FluentNHibernate/MappingModel/Output/XmlIdBagWriter.cs
@@ -1,0 +1,39 @@
+using System.Xml;
+using FluentNHibernate.MappingModel.Collections;
+using FluentNHibernate.MappingModel.Identity;
+using FluentNHibernate.Utils;
+
+namespace FluentNHibernate.MappingModel.Output;
+
+public class XmlIdBagWriter(IXmlWriterServiceLocator serviceLocator) : BaseXmlCollectionWriter(serviceLocator), IXmlWriter<CollectionMapping>
+{
+    readonly IXmlWriterServiceLocator _serviceLocator = serviceLocator;
+
+    public XmlDocument Write(CollectionMapping mappingModel)
+    {
+        document = null;
+        mappingModel.AcceptVisitor(this);
+        return document;
+    }
+
+    public override void ProcessCollection(CollectionMapping mapping)
+    {
+        document = new XmlDocument();
+        var element = document.AddElement("idbag");
+        WriteBaseCollectionAttributes(element, mapping);
+    }
+    
+    public override void Visit(CollectionIdMapping mapping)
+    {
+        var writer = _serviceLocator.GetWriter<CollectionIdMapping>();
+        var xml = writer.Write(mapping);
+        document.ImportAndAppendChild(xml);
+    }
+    
+    public override void Visit(GeneratorMapping mapping)
+    {
+        var writer = _serviceLocator.GetWriter<GeneratorMapping>();
+        var generatorXml = writer.Write(mapping);
+        document.ImportAndAppendChild(generatorXml);
+    }
+}

--- a/src/FluentNHibernate/MappingModel/Output/XmlListWriter.cs
+++ b/src/FluentNHibernate/MappingModel/Output/XmlListWriter.cs
@@ -7,8 +7,6 @@ namespace FluentNHibernate.MappingModel.Output;
 public class XmlListWriter(IXmlWriterServiceLocator serviceLocator)
     : BaseXmlCollectionWriter(serviceLocator), IXmlWriter<CollectionMapping>
 {
-    readonly IXmlWriterServiceLocator serviceLocator = serviceLocator;
-
     public XmlDocument Write(CollectionMapping mappingModel)
     {
         document = null;

--- a/src/FluentNHibernate/MappingModel/Output/XmlMapWriter.cs
+++ b/src/FluentNHibernate/MappingModel/Output/XmlMapWriter.cs
@@ -7,8 +7,6 @@ namespace FluentNHibernate.MappingModel.Output;
 public class XmlMapWriter(IXmlWriterServiceLocator serviceLocator)
     : BaseXmlCollectionWriter(serviceLocator), IXmlWriter<CollectionMapping>
 {
-    readonly IXmlWriterServiceLocator serviceLocator = serviceLocator;
-
     public XmlDocument Write(CollectionMapping mappingModel)
     {
         document = null;

--- a/src/FluentNHibernate/MappingModel/Output/XmlWriterContainer.cs
+++ b/src/FluentNHibernate/MappingModel/Output/XmlWriterContainer.cs
@@ -129,6 +129,9 @@ public class XmlWriterContainer : Container
 
         RegisterWriter<KeyManyToOneMapping>(c =>
             new XmlKeyManyToOneWriter(c.Resolve<IXmlWriterServiceLocator>()));
+        
+        RegisterWriter<CollectionIdMapping>(c =>
+            new XmlCollectionIdWriter(c.Resolve<IXmlWriterServiceLocator>()));
     }
 
     void RegisterComponentWriters()

--- a/src/FluentNHibernate/Visitors/ConventionVisitor.cs
+++ b/src/FluentNHibernate/Visitors/ConventionVisitor.cs
@@ -95,7 +95,10 @@ public class ConventionVisitor : DefaultMappingModelVisitor
             Apply(conventions, new OneToManyCollectionInstance(mapping));
         }
 
-        collections[mapping.Collection](mapping);
+        if (collections.TryGetValue(mapping.Collection, out var processor))
+        {
+            processor(mapping);
+        }
     }
 
 #pragma warning disable 612,618

--- a/src/FluentNHibernate/Visitors/DefaultMappingModelVisitor.cs
+++ b/src/FluentNHibernate/Visitors/DefaultMappingModelVisitor.cs
@@ -184,4 +184,8 @@ public abstract class DefaultMappingModelVisitor : NullMappingModelVisitor
         mapping.AcceptVisitor(this);
     }
 
+    public override void Visit(CollectionIdMapping mapping)
+    {
+        mapping.AcceptVisitor(this);
+    }
 }

--- a/src/FluentNHibernate/Visitors/IMappingModelVisitor.cs
+++ b/src/FluentNHibernate/Visitors/IMappingModelVisitor.cs
@@ -44,6 +44,7 @@ public interface IMappingModelVisitor
     void ProcessStoredProcedure(StoredProcedureMapping mapping);
     void ProcessTuplizer(TuplizerMapping mapping);
     void ProcessCollection(MappingModel.Collections.CollectionMapping mapping);
+    void ProcessCollectionId(CollectionIdMapping mapping);
 
     /// <summary>
     /// This bad boy is the entry point to the visitor
@@ -84,4 +85,5 @@ public interface IMappingModelVisitor
     void Visit(FilterDefinitionMapping mapping);
     void Visit(StoredProcedureMapping mapping);
     void Visit(TuplizerMapping mapping);
+    void Visit(CollectionIdMapping mapping);
 }

--- a/src/FluentNHibernate/Visitors/NullMappingModelVisitor.cs
+++ b/src/FluentNHibernate/Visitors/NullMappingModelVisitor.cs
@@ -188,6 +188,11 @@ public abstract class NullMappingModelVisitor : IMappingModelVisitor
             
     }
 
+    public virtual void ProcessCollectionId(CollectionIdMapping mapping)
+    {
+        
+    }
+
     public virtual void Visit(IEnumerable<HibernateMapping> mappings)
     {
             
@@ -355,5 +360,10 @@ public abstract class NullMappingModelVisitor : IMappingModelVisitor
     public virtual void Visit(TuplizerMapping mapping)
     {
             
+    }
+
+    public virtual void Visit(CollectionIdMapping mapping)
+    {
+        
     }
 }

--- a/src/FluentNHibernate/Visitors/ValidationVisitor.cs
+++ b/src/FluentNHibernate/Visitors/ValidationVisitor.cs
@@ -33,8 +33,6 @@ public class ValidationVisitor : DefaultMappingModelVisitor
                 "Remove Inverse from one side of the relationship",
                 mapping.ContainingEntityType);
         }
-        
-        //if (mapping.Collection == Collection.IdBag && mapping.Relationship.)
     }
 
     /// <summary>

--- a/src/FluentNHibernate/Visitors/ValidationVisitor.cs
+++ b/src/FluentNHibernate/Visitors/ValidationVisitor.cs
@@ -33,6 +33,8 @@ public class ValidationVisitor : DefaultMappingModelVisitor
                 "Remove Inverse from one side of the relationship",
                 mapping.ContainingEntityType);
         }
+        
+        //if (mapping.Collection == Collection.IdBag && mapping.Relationship.)
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #415 

Adds the ability to specify a collection .AsIdBag(). Note that the NHibernate xml mapping model is a little odd:

- The column attribute on collection-id is always required even though a column element can technically be specified.
- The type attribute is required and must be a .net type (varchar will throw an exception)
- The idbag is identical to the bag mapping, with the 2 exceptions:
  - The idbag has a collection-id element
  - The idbag doesn't have one-to-many