### PR TITLE
Reject subselect fetching for join, many-to-one and one-to-one associations

### DIFF
--- a/src/FluentNHibernate.Testing/ConventionsTests/FetchInstanceRestrictionTester.cs
+++ b/src/FluentNHibernate.Testing/ConventionsTests/FetchInstanceRestrictionTester.cs
@@ -1,0 +1,45 @@
+using System;
+using FluentNHibernate.Conventions.Inspections;
+using FluentNHibernate.Conventions.Instances;
+using FluentNHibernate.MappingModel;
+using NUnit.Framework;
+
+namespace FluentNHibernate.Testing.ConventionsTests;
+
+[TestFixture]
+public class FetchInstanceRestrictionTester
+{
+    [Test]
+    public void join_convention_fetch_select_is_allowed()
+    {
+        var mapping = new JoinMapping();
+
+        new JoinInstance(mapping).Fetch.Select();
+
+        mapping.Fetch.ShouldEqual("select");
+    }
+
+    [Test]
+    public void join_convention_fetch_subselect_throws()
+    {
+        var instance = new JoinInstance(new JoinMapping());
+
+        Assert.Throws<NotSupportedException>(() => instance.Fetch.Subselect());
+    }
+
+    [Test]
+    public void many_to_one_convention_fetch_subselect_throws()
+    {
+        var instance = new ManyToOneInstance(new ManyToOneMapping());
+
+        Assert.Throws<NotSupportedException>(() => instance.Fetch.Subselect());
+    }
+
+    [Test]
+    public void one_to_one_convention_fetch_subselect_throws()
+    {
+        var instance = new OneToOneInstance(new OneToOneMapping());
+
+        Assert.Throws<NotSupportedException>(() => instance.Fetch.Subselect());
+    }
+}

--- a/src/FluentNHibernate.Testing/DomainModel/Mapping/FetchSubselectRestrictionTester.cs
+++ b/src/FluentNHibernate.Testing/DomainModel/Mapping/FetchSubselectRestrictionTester.cs
@@ -1,0 +1,90 @@
+using System;
+using FluentNHibernate.Mapping;
+using NUnit.Framework;
+
+namespace FluentNHibernate.Testing.DomainModel.Mapping;
+
+[TestFixture]
+public class FetchSubselectRestrictionTester
+{
+    [Test]
+    public void join_fetch_subselect_throws()
+    {
+        var join = new JoinPart<Target>("secondary");
+
+        Assert.Throws<NotSupportedException>(() => join.Fetch.Subselect());
+    }
+
+    [Test]
+    public void join_fetch_join_is_allowed()
+    {
+        var join = new JoinPart<Target>("secondary");
+
+        Assert.DoesNotThrow(() => join.Fetch.Join());
+    }
+
+    [Test]
+    public void join_fetch_select_is_allowed()
+    {
+        var join = new JoinPart<Target>("secondary");
+
+        Assert.DoesNotThrow(() => join.Fetch.Select());
+    }
+
+    [Test]
+    public void many_to_one_fetch_subselect_throws()
+    {
+        Assert.Throws<NotSupportedException>(() => new ManyToOneSubselectMap());
+    }
+
+    [Test]
+    public void one_to_one_fetch_subselect_throws()
+    {
+        Assert.Throws<NotSupportedException>(() => new OneToOneSubselectMap());
+    }
+
+    [Test]
+    public void fetch_property_return_types_stay_the_base_type_for_binary_compatibility()
+    {
+        // These must remain FetchTypeExpression<T> (not a derived type). Widening a
+        // return type is a binary breaking change: an assembly compiled against a
+        // previous FluentNHibernate release would fail with MissingMethodException
+        // when this build is dropped in as a replacement.
+        Assert.That(typeof(JoinPart<Target>).GetProperty("Fetch").PropertyType,
+            Is.EqualTo(typeof(FetchTypeExpression<JoinPart<Target>>)));
+        Assert.That(typeof(ManyToOnePart<Other>).GetProperty("Fetch").PropertyType,
+            Is.EqualTo(typeof(FetchTypeExpression<ManyToOnePart<Other>>)));
+        Assert.That(typeof(OneToOnePart<Target>).GetProperty("Fetch").PropertyType,
+            Is.EqualTo(typeof(FetchTypeExpression<OneToOnePart<Target>>)));
+    }
+
+    class Target
+    {
+        public int Id { get; set; }
+        public Other Other { get; set; }
+    }
+
+    class Other
+    {
+        public int Id { get; set; }
+        public Target Target { get; set; }
+    }
+
+    class ManyToOneSubselectMap : ClassMap<Target>
+    {
+        public ManyToOneSubselectMap()
+        {
+            Id(x => x.Id);
+            References(x => x.Other).Fetch.Subselect();
+        }
+    }
+
+    class OneToOneSubselectMap : ClassMap<Other>
+    {
+        public OneToOneSubselectMap()
+        {
+            Id(x => x.Id);
+            HasOne(x => x.Target).Fetch.Subselect();
+        }
+    }
+}

--- a/src/FluentNHibernate.Testing/DomainModel/Mapping/FetchTypeExpressionTester.cs
+++ b/src/FluentNHibernate.Testing/DomainModel/Mapping/FetchTypeExpressionTester.cs
@@ -10,7 +10,7 @@ public class FetchTypeExpressionTester
     #region Test Setup
     public FetchTypeExpression<object> _fetchType;
     string fetchValue;
-		
+
     [SetUp]
     public virtual void SetUp()
     {
@@ -44,8 +44,18 @@ public class FetchTypeExpressionTester
     }
 
     [Test]
-    public void Subselect_should_add_the_correct_fetch_attribute_to_the_parent_part()
+    public void Subselect_should_throw_because_it_is_not_supported_for_associations()
     {
-        A_call_to(_fetchType.Subselect).should_set_the_fetch_value_to("subselect");
+        Assert.Throws<NotSupportedException>(() => _fetchType.Subselect());
+    }
+
+    [Test]
+    public void Subselect_on_a_collection_fetch_should_add_the_correct_fetch_attribute()
+    {
+        var collectionFetchType = new CollectionFetchTypeExpression<object>(null, value => fetchValue = value);
+
+        collectionFetchType.Subselect();
+
+        fetchValue.ShouldEqual("subselect");
     }
 }

--- a/src/FluentNHibernate.Testing/FluentInterfaceTests/OneToManyMutablePropertyModelGenerationTests.cs
+++ b/src/FluentNHibernate.Testing/FluentInterfaceTests/OneToManyMutablePropertyModelGenerationTests.cs
@@ -115,7 +115,7 @@ public class OneToManyMutablePropertyModelGenerationTests : BaseModelFixture
             .Mapping(m => m.Not.LazyLoad())
             .ModelShouldMatch(x => x.Lazy.ShouldEqual(Lazy.False));
     }
-        
+
     [Test]
     public void ExtraLazyLoadShouldSetModelLazyPropertyToExtra()
     {
@@ -178,6 +178,14 @@ public class OneToManyMutablePropertyModelGenerationTests : BaseModelFixture
         OneToMany(x => x.BagOfChildren)
             .Mapping(m => m.Fetch.Select())
             .ModelShouldMatch(x => x.Fetch.ShouldEqual("select"));
+    }
+
+    [Test]
+    public void FetchSubselectShouldSetModelFetchPropertyToSubselect()
+    {
+        OneToMany(x => x.BagOfChildren)
+            .Mapping(m => m.Fetch.Subselect())
+            .ModelShouldMatch(x => x.Fetch.ShouldEqual("subselect"));
     }
 
     [Test]

--- a/src/FluentNHibernate/Conventions/Instances/CollectionFetchInstance.cs
+++ b/src/FluentNHibernate/Conventions/Instances/CollectionFetchInstance.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace FluentNHibernate.Conventions.Instances;
+
+public class CollectionFetchInstance(Action<string> setter)
+    : FetchInstance(setter)
+{
+    public override void Subselect()
+    {
+        Setter("subselect");
+    }
+}

--- a/src/FluentNHibernate/Conventions/Instances/CollectionInstance.cs
+++ b/src/FluentNHibernate/Conventions/Instances/CollectionInstance.cs
@@ -30,10 +30,7 @@ public class CollectionInstance(CollectionMapping mapping) : CollectionInspector
         get { return new CollectionCascadeInstance(value => mapping.Set(x => x.Cascade, Layer.Conventions, value)); }
     }
 
-    public new IFetchInstance Fetch
-    {
-        get { return new CollectionFetchInstance(value => mapping.Set(x => x.Fetch, Layer.Conventions, value)); }
-    }
+    public new IFetchInstance Fetch => new CollectionFetchInstance(value => mapping.Set(x => x.Fetch, Layer.Conventions, value));
 
     public new void OptimisticLock()
     {

--- a/src/FluentNHibernate/Conventions/Instances/CollectionInstance.cs
+++ b/src/FluentNHibernate/Conventions/Instances/CollectionInstance.cs
@@ -32,7 +32,7 @@ public class CollectionInstance(CollectionMapping mapping) : CollectionInspector
 
     public new IFetchInstance Fetch
     {
-        get { return new FetchInstance(value => mapping.Set(x => x.Fetch, Layer.Conventions, value)); }
+        get { return new CollectionFetchInstance(value => mapping.Set(x => x.Fetch, Layer.Conventions, value)); }
     }
 
     public new void OptimisticLock()
@@ -147,7 +147,7 @@ public class CollectionInstance(CollectionMapping mapping) : CollectionInspector
         mapping.Set(x => x.Lazy, Layer.Conventions, nextBool ? Lazy.True : Lazy.False);
         nextBool = true;
     }
-        
+
     public override void ExtraLazyLoad()
     {
         mapping.Set(x => x.Lazy, Layer.Conventions, nextBool ? Lazy.Extra : Lazy.True);
@@ -201,13 +201,13 @@ public class CollectionInstance(CollectionMapping mapping) : CollectionInspector
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public ICollectionInstance Not
     {
-        get 
+        get
         {
             nextBool = !nextBool;
-            return this; 
+            return this;
         }
     }
-        
+
     public new ICacheInstance Cache
     {
         get
@@ -238,7 +238,7 @@ public class CollectionInstance(CollectionMapping mapping) : CollectionInspector
         {
             if (mapping.Element is null)
                 mapping.Set(x => x.Element, Layer.Conventions, new ElementMapping());
-                
+
             return new ElementInstance(mapping.Element);
         }
     }

--- a/src/FluentNHibernate/Conventions/Instances/FetchInstance.cs
+++ b/src/FluentNHibernate/Conventions/Instances/FetchInstance.cs
@@ -4,18 +4,28 @@ namespace FluentNHibernate.Conventions.Instances;
 
 public class FetchInstance(Action<string> setter) : IFetchInstance
 {
+    internal const string SubselectNotSupportedMessage =
+        "Subselect fetching is not supported for join, many-to-one and one-to-one associations; " +
+        "NHibernate only allows join or select fetching for these. Use Select or Join instead.";
+
+    private protected readonly Action<string> Setter = setter;
+
     public void Join()
     {
-        setter("join");
+        Setter("join");
     }
 
     public void Select()
     {
-        setter("select");
+        Setter("select");
     }
 
-    public void Subselect()
+    /// <summary>
+    /// Subselect fetching. Only supported for collections; throws for join,
+    /// many-to-one and one-to-one associations.
+    /// </summary>
+    public virtual void Subselect()
     {
-        setter("subselect");
+        throw new NotSupportedException(SubselectNotSupportedMessage);
     }
 }

--- a/src/FluentNHibernate/Mapping/CollectionFetchTypeExpression.cs
+++ b/src/FluentNHibernate/Mapping/CollectionFetchTypeExpression.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace FluentNHibernate.Mapping;
+
+/// <summary>
+/// Fetching strategies for collections, which map to NHibernate's <c>fetch</c>
+/// attribute with the <c>collectionFetchMode</c> type. In addition to <c>join</c>
+/// and <c>select</c>, collections also support <c>subselect</c>.
+/// </summary>
+public class CollectionFetchTypeExpression<TParent>(TParent parent, Action<string> setter)
+    : FetchTypeExpression<TParent>(parent, setter)
+{
+    /// <summary>
+    /// Subselect/subquery fetching
+    /// </summary>
+    public override TParent Subselect()
+    {
+        Setter("subselect");
+        return Parent;
+    }
+}

--- a/src/FluentNHibernate/Mapping/FetchTypeExpression.cs
+++ b/src/FluentNHibernate/Mapping/FetchTypeExpression.cs
@@ -2,15 +2,28 @@ using System;
 
 namespace FluentNHibernate.Mapping;
 
+/// <summary>
+/// Fetching strategies for associations that map to NHibernate's <c>fetch</c>
+/// attribute with the <c>fetchMode</c> type (join, many-to-one, one-to-one), which
+/// only supports <c>join</c> and <c>select</c>. Collections additionally support
+/// <c>subselect</c> via <see cref="CollectionFetchTypeExpression{TParent}"/>.
+/// </summary>
 public class FetchTypeExpression<TParent>(TParent parent, Action<string> setter)
 {
+    private const string SubselectNotSupportedMessage =
+        "Subselect fetching is not supported for join, many-to-one and one-to-one associations; " +
+        "NHibernate only allows join or select fetching for these. Use Select or Join instead.";
+
+    private protected readonly TParent Parent = parent;
+    private protected readonly Action<string> Setter = setter;
+
     /// <summary>
     /// Join fetching
     /// </summary>
     public TParent Join()
     {
-        setter("join");
-        return parent;
+        Setter("join");
+        return Parent;
     }
 
     /// <summary>
@@ -18,16 +31,13 @@ public class FetchTypeExpression<TParent>(TParent parent, Action<string> setter)
     /// </summary>
     public TParent Select()
     {
-        setter("select");
-        return parent;
+        Setter("select");
+        return Parent;
     }
 
     /// <summary>
-    /// Subselect/subquery fetching
+    /// Subselect/subquery fetching. Only supported for collections; throws for
+    /// join, many-to-one and one-to-one associations.
     /// </summary>
-    public TParent Subselect()
-    {
-        setter("subselect");
-        return parent;
-    }
+    public virtual TParent Subselect() => throw new NotSupportedException(SubselectNotSupportedMessage);
 }

--- a/src/FluentNHibernate/Mapping/ManyToManyPart.cs
+++ b/src/FluentNHibernate/Mapping/ManyToManyPart.cs
@@ -28,7 +28,7 @@ public class ManyToManyPart<TChild> : ToManyBase<ManyToManyPart<TChild>, TChild>
     {
         childType = collectionType;
 
-        FetchType = new FetchTypeExpression<ManyToManyPart<TChild>>(this, value => collectionAttributes.Set("Fetch", Layer.UserSupplied, value));
+        FetchType = new CollectionFetchTypeExpression<ManyToManyPart<TChild>>(this, value => collectionAttributes.Set("Fetch", Layer.UserSupplied, value));
         NotFound = new NotFoundExpression<ManyToManyPart<TChild>>(this, value => relationshipAttributes.Set("NotFound", Layer.UserSupplied, value));
 
         ChildKeyColumns = new ColumnMappingCollection<ManyToManyPart<TChild>>(this);
@@ -40,7 +40,7 @@ public class ManyToManyPart<TChild> : ToManyBase<ManyToManyPart<TChild>, TChild>
     /// </summary>
     public ManyToManyPart<TChild> ChildKeyColumn(string childKeyColumn)
     {
-        ChildKeyColumns.Clear(); 
+        ChildKeyColumns.Clear();
         ChildKeyColumns.Add(childKeyColumn);
         return this;
     }
@@ -50,7 +50,7 @@ public class ManyToManyPart<TChild> : ToManyBase<ManyToManyPart<TChild>, TChild>
     /// </summary>
     public ManyToManyPart<TChild> ParentKeyColumn(string parentKeyColumn)
     {
-        ParentKeyColumns.Clear(); 
+        ParentKeyColumns.Clear();
         ParentKeyColumns.Add(parentKeyColumn);
         return this;
     }
@@ -98,7 +98,7 @@ public class ManyToManyPart<TChild> : ToManyBase<ManyToManyPart<TChild>, TChild>
 
     public ManyToManyPart<TChild> AsTernaryAssociation(string indexColumn, string valueColumn)
     {
-        return AsTernaryAssociation(indexColumn, valueColumn, x => {});
+        return AsTernaryAssociation(indexColumn, valueColumn, x => { });
     }
 
     public ManyToManyPart<TChild> AsTernaryAssociation(string indexColumn, string valueColumn, Action<IndexManyToManyPart> indexAction)
@@ -129,7 +129,7 @@ public class ManyToManyPart<TChild> : ToManyBase<ManyToManyPart<TChild>, TChild>
 
     public ManyToManyPart<TChild> AsTernaryAssociation(Type indexType, string indexColumn, Type typeOfValue, string valueColumn)
     {
-        return AsTernaryAssociation(indexType, indexColumn, typeOfValue, valueColumn, x => {});
+        return AsTernaryAssociation(indexType, indexColumn, typeOfValue, valueColumn, x => { });
     }
 
     public ManyToManyPart<TChild> AsTernaryAssociation(Type indexType, string indexColumn, Type typeOfValue, string valueColumn, Action<IndexManyToManyPart> indexAction)

--- a/src/FluentNHibernate/Mapping/ToManyBase.cs
+++ b/src/FluentNHibernate/Mapping/ToManyBase.cs
@@ -31,7 +31,7 @@ public abstract class ToManyBase<T, TChild> : ICollectionMappingProvider
         this.member = member;
         AsBag();
         Access = new AccessStrategyBuilder<T>((T)this, value => collectionAttributes.Set("Access", Layer.UserSupplied, value));
-        Fetch = new FetchTypeExpression<T>((T)this, value => collectionAttributes.Set("Fetch", Layer.UserSupplied, value));
+        Fetch = new CollectionFetchTypeExpression<T>((T)this, value => collectionAttributes.Set("Fetch", Layer.UserSupplied, value));
         Cascade = new CollectionCascadeExpression<T>((T)this, value =>
         {
             var current = collectionAttributes.Get("Cascade") as string;


### PR DESCRIPTION
NHibernate does not allow subselect fetch for a join, a many-to-one, or a one-to-one association, it is valid for collections only.

Previously, these associations accepted `Fetch.Subselect()` and produced and invalid mapping that resulted in NHibernate failing with an unclear message. Now they throw a clear error. 

Closes #738