### PR TITLE
Map id-named members as properties when they are not the id

### DIFF
--- a/src/FluentNHibernate.Specs/Automapping/OverrideSpecs.cs
+++ b/src/FluentNHibernate.Specs/Automapping/OverrideSpecs.cs
@@ -97,6 +97,12 @@ public class when_using_an_automapping_override_to_specify_a_different_id
     It should_map_id_as_different_id = () =>
         ((IdMapping)mapping.Id).Name.ShouldEqual("DestinationId");
 
+    It should_map_the_leftover_id_named_member_as_a_property = () =>
+        mapping.Properties.Select(x => x.Name).ShouldContain("Id");
+
+    It should_not_also_map_the_overridden_id_as_a_property = () =>
+        mapping.Properties.Select(x => x.Name).ShouldNotContain("DestinationId");
+
     static AutoPersistenceModel model;
     static ClassMapping mapping;
 }

--- a/src/FluentNHibernate.Testing/AutoMapping/Apm/SubclassIdentityTests.cs
+++ b/src/FluentNHibernate.Testing/AutoMapping/Apm/SubclassIdentityTests.cs
@@ -1,0 +1,50 @@
+using System.Linq;
+using FluentNHibernate.Automapping;
+using FluentNHibernate.MappingModel.ClassBased;
+using NUnit.Framework;
+
+namespace FluentNHibernate.Testing.AutoMapping.Apm;
+
+[TestFixture]
+public class SubclassIdentityTests
+{
+    [Test]
+    public void SubclassMemberMatchingIdConventionIsMappedAsPropertyNotSwallowed()
+    {
+        var model = AutoMap.Source(new StubTypeSource(typeof(Vehicle), typeof(Car)), new PerTypeIdConvention())
+            .Override<Vehicle>(m => m.DiscriminateSubClassesOnColumn("type"));
+
+        var root = (ClassMapping)model.BuildMappings()
+            .SelectMany(x => x.Classes)
+            .Single(c => c.Type == typeof(Vehicle));
+        var subclass = root.Subclasses.Single();
+
+        // Car.CarId matches the id convention, but a subclass has no id of its own so the
+        // identity step's Map is a no-op for it. It must not be claimed (and thereby
+        // swallowed) by the identity step — it has to fall through and be mapped as a
+        // regular property.
+        subclass.Properties.Select(x => x.Name).ShouldContain("CarId");
+    }
+}
+
+// Treats "Id" and "<TypeName>Id" as the identifier — a common convention that also makes a
+// subclass expose a member matching the rule.
+class PerTypeIdConvention : DefaultAutomappingConfiguration
+{
+    public override bool IsId(Member member)
+    {
+        return member.Name == "Id" || member.Name == member.DeclaringType.Name + "Id";
+    }
+}
+
+class Vehicle
+{
+    public int Id { get; set; }
+    public string Make { get; set; }
+}
+
+class Car : Vehicle
+{
+    public int CarId { get; set; }
+    public string Model { get; set; }
+}

--- a/src/FluentNHibernate.Testing/AutoMapping/Steps/IdentityStepTests.cs
+++ b/src/FluentNHibernate.Testing/AutoMapping/Steps/IdentityStepTests.cs
@@ -1,0 +1,64 @@
+using FluentNHibernate.Automapping;
+using FluentNHibernate.Automapping.Steps;
+using FluentNHibernate.MappingModel;
+using FluentNHibernate.MappingModel.ClassBased;
+using FluentNHibernate.MappingModel.Identity;
+using FluentNHibernate.Utils.Reflection;
+using NUnit.Framework;
+
+namespace FluentNHibernate.Testing.AutoMapping.Steps;
+
+[TestFixture]
+public class IdentityStepTests
+{
+    IdentityStep mapper;
+
+    [SetUp]
+    public void CreateMapper()
+    {
+        mapper = new IdentityStep(new DefaultAutomappingConfiguration());
+    }
+
+    [Test]
+    public void ShouldMapIdOnClassThatHasNoIdYet()
+    {
+        mapper.ShouldMap(new ClassMapping(), MemberFor("Id")).ShouldBeTrue();
+    }
+
+    [Test]
+    public void ShouldNotMapNonIdMember()
+    {
+        mapper.ShouldMap(new ClassMapping(), MemberFor("Name")).ShouldBeFalse();
+    }
+
+    [Test]
+    public void ShouldNotMapIdOnClassThatAlreadyHasAnId()
+    {
+        var mapping = new ClassMapping();
+        mapping.Set(x => x.Id, Layer.UserSupplied, new IdMapping());
+
+        mapper.ShouldMap(mapping, MemberFor("Id")).ShouldBeFalse();
+    }
+
+    [Test]
+    public void ShouldNotMapIdOnSubclass()
+    {
+        // Map does nothing for anything that isn't a ClassMapping, so an id member must not
+        // be claimed here for a subclass; otherwise it is added to the mapped members (and
+        // the loop stops trying other steps) yet never actually mapped.
+        var subclass = new SubclassMapping(SubclassType.Subclass);
+
+        mapper.ShouldMap(subclass, MemberFor("Id")).ShouldBeFalse();
+    }
+
+    static Member MemberFor(string name)
+    {
+        return typeof(Target).GetProperty(name).ToMember();
+    }
+
+    class Target
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+    }
+}

--- a/src/FluentNHibernate/Automapping/AutoMapper.cs
+++ b/src/FluentNHibernate/Automapping/AutoMapper.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using FluentNHibernate.Automapping.Steps;
 using FluentNHibernate.Conventions;
 using FluentNHibernate.MappingModel;
 using FluentNHibernate.MappingModel.ClassBased;
@@ -157,14 +158,21 @@ public class AutoMapper(
 
         foreach (var rule in cfg.GetMappingSteps(this, conventionFinder))
         {
-            if (!rule.ShouldMap(member)) continue;
             if (mappedMembers.Contains(member)) continue;
+            if (!ShouldMap(rule, mapping, member)) continue;
 
             rule.Map(mapping, member);
             mappedMembers.Add(member);
 
             break;
         }
+    }
+
+    private static bool ShouldMap(IAutomappingStep rule, ClassMappingBase mapping, Member member)
+    {
+        return rule is IContextAwareAutomappingStep contextual
+            ? contextual.ShouldMap(mapping, member)
+            : rule.ShouldMap(member);
     }
 
     public ClassMapping Map(Type classType, List<AutoMapType> types)

--- a/src/FluentNHibernate/Automapping/Steps/IContextAwareAutomappingStep.cs
+++ b/src/FluentNHibernate/Automapping/Steps/IContextAwareAutomappingStep.cs
@@ -1,0 +1,12 @@
+using FluentNHibernate.MappingModel.ClassBased;
+
+namespace FluentNHibernate.Automapping.Steps;
+
+/// <summary>
+/// An automapping step whose decision to map a member can depend on what has already
+/// been mapped on the class, not just on the member in isolation.
+/// </summary>
+public interface IContextAwareAutomappingStep
+{
+    bool ShouldMap(ClassMappingBase classMap, Member member);
+}

--- a/src/FluentNHibernate/Automapping/Steps/IdentityStep.cs
+++ b/src/FluentNHibernate/Automapping/Steps/IdentityStep.cs
@@ -7,7 +7,7 @@ using FluentNHibernate.MappingModel.Identity;
 
 namespace FluentNHibernate.Automapping.Steps;
 
-public class IdentityStep(IAutomappingConfiguration cfg) : IAutomappingStep
+public class IdentityStep(IAutomappingConfiguration cfg) : IAutomappingStep, IContextAwareAutomappingStep
 {
     readonly List<Type> identityCompatibleTypes = new List<Type> { typeof(long), typeof(int), typeof(short), typeof(byte) };
 
@@ -16,9 +16,14 @@ public class IdentityStep(IAutomappingConfiguration cfg) : IAutomappingStep
         return cfg.IsId(member);
     }
 
+    public bool ShouldMap(ClassMappingBase classMap, Member member)
+    {
+        return classMap is ClassMapping { Id: null } && ShouldMap(member);
+    }
+
     public void Map(ClassMappingBase classMap, Member member)
     {
-        if (!(classMap is ClassMapping)) return;
+        if (classMap is not ClassMapping) return;
 
         var idMapping = new IdMapping { ContainingEntityType = classMap.Type };
         var columnMapping = new ColumnMapping();


### PR DESCRIPTION
A property that matches the id convention but is not the id, for example, because an override chose a different property, or because it is on a subclass, is now mapped as a normal column instead of being dropped.

Fixes #299