### PR TITLE
Pass the member to id conventions for fluently mapped ids

### DIFF
--- a/src/FluentNHibernate.Testing/AutoMapping/Apm/Conventions/OverriddenIdConventionTests.cs
+++ b/src/FluentNHibernate.Testing/AutoMapping/Apm/Conventions/OverriddenIdConventionTests.cs
@@ -1,0 +1,52 @@
+using FluentNHibernate.Automapping;
+using FluentNHibernate.Conventions;
+using FluentNHibernate.Conventions.Instances;
+using NUnit.Framework;
+
+namespace FluentNHibernate.Testing.AutoMapping.Apm.Conventions;
+
+[TestFixture]
+public class OverriddenIdConventionTests
+{
+    [Test]
+    public void OverriddenIdPassesTheMemberToIdConventions()
+    {
+        CapturingIdConvention.Reset();
+
+        AutoMap.Source(new StubTypeSource(typeof(OverriddenIdEntity)))
+            .Override<OverriddenIdEntity>(m => m.Id(x => x.Id))
+            .Conventions.Add<CapturingIdConvention>()
+            .BuildMappings();
+
+        CapturingIdConvention.WasApplied.ShouldBeTrue();
+        CapturingIdConvention.PropertyName.ShouldEqual("Id");
+    }
+
+    class CapturingIdConvention : IIdConvention
+    {
+        public static bool WasApplied;
+        public static string PropertyName;
+
+        public static void Reset()
+        {
+            WasApplied = false;
+            PropertyName = null;
+        }
+
+        public void Apply(IIdentityInstance instance)
+        {
+            WasApplied = true;
+            PropertyName = instance.Property?.Name;
+        }
+    }
+}
+
+public abstract class OverriddenIdBase
+{
+    public virtual int Id { get; set; }
+}
+
+public class OverriddenIdEntity : OverriddenIdBase
+{
+    public virtual string SomeField { get; set; }
+}

--- a/src/FluentNHibernate.Testing/DomainModel/Mapping/IdentityPartTester.cs
+++ b/src/FluentNHibernate.Testing/DomainModel/Mapping/IdentityPartTester.cs
@@ -2,6 +2,7 @@ using System;
 using FluentNHibernate.Conventions;
 using FluentNHibernate.Conventions.Instances;
 using FluentNHibernate.Mapping;
+using FluentNHibernate.Mapping.Providers;
 using FluentNHibernate.Utils.Reflection;
 using NUnit.Framework;
 
@@ -456,6 +457,17 @@ public class IdentityPartTester
         Assert.That(() =>
                 new IdentityPart(typeof(IdentityTarget), property).GeneratedBy.Native(),
             Throws.TypeOf<InvalidOperationException>());
+    }
+
+    [Test]
+    public void SetsMemberOnMapping()
+    {
+        var member = typeof(IdentityTarget).GetProperty("IntId").ToMember();
+        var part = new IdentityPart(typeof(IdentityTarget), member);
+
+        var mapping = ((IIdentityMappingProvider)part).GetIdentityMapping();
+
+        mapping.Member.ShouldEqual(member);
     }
 
     [Test]

--- a/src/FluentNHibernate/Mapping/IdentityPart.cs
+++ b/src/FluentNHibernate/Mapping/IdentityPart.cs
@@ -266,7 +266,8 @@ public class IdentityPart : IIdentityMappingProvider
     {
         var mapping = new IdMapping(attributes.Clone())
         {
-            ContainingEntityType = entityType
+            ContainingEntityType = entityType,
+            Member = member,
         };
 
         if (columns.Count > 0)


### PR DESCRIPTION
An id mapped fluently or through an automapping override did not keep its member, so id conventions got a null `Property`.

Fixes #276